### PR TITLE
Made TornadoInsight compatible with the latest version 233.*

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -23,7 +23,7 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameter;
 import uk.ac.manchester.beehive.tornado.plugins.util.MessageUtils;
 import uk.ac.manchester.beehive.tornado.plugins.util.MethodUtil;
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/listener/TornadoSettingListener.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/listener/TornadoSettingListener.java
@@ -24,17 +24,16 @@ import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.startup.StartupActivity;
 import uk.ac.manchester.beehive.tornado.plugins.entity.EnvironmentVariable;
 import uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingState;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
-public class TornadoSettingListener implements ProjectManagerListener {
-
+public class TornadoSettingListener implements StartupActivity {
     @Override
-    public void projectOpened(@NotNull Project project) {
+    public void runActivity(@NotNull Project project) {
         if (TornadoSettingState.getInstance().TornadoRoot == null) {
             TornadoSettingState.getInstance().isValid = false;
             Notification notification = new Notification("Print", "TornadoVM",
@@ -51,7 +50,7 @@ public class TornadoSettingListener implements ProjectManagerListener {
         }
     }
 
-     static class OpenTornadoSettingAction extends NotificationAction {
+    static class OpenTornadoSettingAction extends NotificationAction {
 
         public OpenTornadoSettingAction() {
             super("Configure TornadoVM");

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/InspectorInfo.kt
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/InspectorInfo.kt
@@ -62,8 +62,8 @@ fun inspectorPane(): DialogPanel {
                     "control-flow to guarantee that those exceptions never happen. Currently, since TornadoVM compiles " +
                     "at runtime, many of those checks can be assured at runtime.")
         }
-
-        separator()
-                .rowComment("Find more on <a href=\"https://tornadovm.readthedocs.io/en/latest\">TornadoVM documentation</a> ")
+        row {
+            comment("Find more on <a href=\"https://tornadovm.readthedocs.io/en/latest\">TornadoVM documentation</a>")
+        }
     }
 }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/InspectorInfo.kt
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/InspectorInfo.kt
@@ -63,7 +63,7 @@ fun inspectorPane(): DialogPanel {
                     "at runtime, many of those checks can be assured at runtime.")
         }
         row {
-            comment("Find more on <a href=\"https://tornadovm.readthedocs.io/en/latest\">TornadoVM documentation</a>")
+            comment("Find more on the <a href=\"https://tornadovm.readthedocs.io/en/latest\">TornadoVM documentation</a>")
         }
     }
 }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/MessageUtils.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/MessageUtils.java
@@ -33,7 +33,7 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.awt.RelativePoint;
 import uk.ac.manchester.beehive.tornado.plugins.ui.console.ConsoleWindowFactory;
-import org.apache.commons.lang.time.DateFormatUtils;
+import org.apache.commons.lang3.time.DateFormatUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -137,6 +137,7 @@ Enjoy and share your feedback!
         <psi.treeChangeListener implementation="uk.ac.manchester.beehive.tornado.plugins.listener.PsiChangeListener"/>
         <toolWindow factoryClass="uk.ac.manchester.beehive.tornado.plugins.ui.console.ConsoleWindowFactory" id="TornadoInsight Console" anchor="bottom"/>
         <errorHandler implementation="uk.ac.manchester.beehive.tornado.plugins.error.ErrorSubmitter"/>
+        <postStartupActivity implementation="uk.ac.manchester.beehive.tornado.plugins.listener.TornadoSettingListener"/>
     </extensions>
     <actions>
         <group id="tornado.bar">
@@ -156,7 +157,5 @@ Enjoy and share your feedback!
                   topic="com.intellij.openapi.wm.ex.ToolWindowManagerListener"/>
         <listener class="uk.ac.manchester.beehive.tornado.plugins.listener.EditorSwitch"
                   topic="com.intellij.openapi.fileEditor.FileEditorManagerListener"/>
-        <listener class="uk.ac.manchester.beehive.tornado.plugins.listener.TornadoSettingListener"
-                  topic="com.intellij.openapi.project.ProjectManagerListener"/>
     </projectListeners>
 </idea-plugin>


### PR DESCRIPTION
This PR is used to resolve IntelliJ IDEA 2023.3.* compatibility problems. 
### 1. Class not found(2 problems)
>   Access to unresolved class `RandomStringUtils`
>   Access to unresolved class `DateFormatUtils`

**Incompatible Reason:** [Commons-lang and commons-lang2 library is going to be removed](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2023.html#1d21ba2e_40).
**Solution:** The package is intentionally changed from `com.apache.commons.lang` to `com.apache.commons.lang3`.

### 2. Method not found(1 problem)
> Invocation of unresolved method `Panel.DefaultImpls.separator$default`

**Incompatible Reason:** The `Panel.DefaultImpls.separator` method has been removed.
**Solution:** Instead of using a separator, use Row.
**This change will result in a UI change:** 
Before:
<img width="451" alt="image" src="https://github.com/beehive-lab/tornado-insight/assets/35668236/a4ef1478-05a0-49ac-a806-3c6383307040">
After:
<img width="450" alt="image" src="https://github.com/beehive-lab/tornado-insight/assets/35668236/c56d732d-daa6-4e49-9dfd-d2b234620c8e">

### 3. Scheduled for removal method usage(1 problem)
> Scheduled for removal method usage(1): `ProjectManagerListener.projectOpened(Project)`

Incompatible Reason: The method is scheduled for removal.
Solution: Using [Kotlin](https://plugins.jetbrains.com/docs/intellij/using-kotlin.html), implement [ProjectActivity](https://github.com/JetBrains/intellij-community/tree/idea/233.11799.300/platform/core-api/src/com/intellij/openapi/startup/StartupActivity.kt) and register in com.intellij.postStartupActivity extension point.
https://plugins.jetbrains.com/docs/intellij/plugin-components.html#project-open