### PR TITLE
Made TornadoInsight compatible with the latest version 241.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ tasks {
     // Configure the plugin's compatibility range with IntelliJ IDEA builds.
     patchPluginXml {
         sinceBuild.set("222")
-        untilBuild.set("233.*")
+        untilBuild.set("241.*")
     }
     // Configure the plugin signing task.
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ repositories {
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
     // Set the version of IntelliJ IDEA that the plugin targets.
-    version.set("2022.2.5")
+    version.set("2024.1.4")
     // Define the type of the IntelliJ Platform (IC = IntelliJ IDEA Community).
     type.set("IC") // Target IDE Platform
     // Specify any additional plugins this plugin depends on.

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
@@ -33,14 +33,14 @@ import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.IdeBorderFactory;
 import com.intellij.ui.components.JBTextField;
 import com.intellij.util.ui.FormBuilder;
-import com.intellij.util.ui.UI;
+import com.intellij.ui.components.JBLabel;
 import uk.ac.manchester.beehive.tornado.plugins.entity.EnvironmentVariable;
 import uk.ac.manchester.beehive.tornado.plugins.util.MessageBundle;
 
 import javax.swing.*;
+
 import java.io.IOException;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -71,20 +71,22 @@ public class TornadoSettingsComponent {
 
         String INNER_COMMENT = MessageBundle.message("ui.settings.comment.env");
 
-        JPanel innerGrid = UI.PanelFactory.grid().splitColumns()
-                .add(UI.PanelFactory.panel(myTornadoEnv).withLabel(MessageBundle.message("ui.settings.label.tornado")))
-                .add(UI.PanelFactory.panel(myJdk).withLabel(MessageBundle.message("ui.settings.label.java")))
-                .createPanel();
+        JPanel innerGrid = FormBuilder.createFormBuilder()
+                .addLabeledComponent(new JBLabel("TornadoVM Root:"), myTornadoEnv)
+                .addLabeledComponent(new JBLabel("Java SDK:"), myJdk)
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + INNER_COMMENT + "</div></html>"))
+                .addVerticalGap(10)
+                .getPanel();
 
-        JPanel panel = UI.PanelFactory.panel(innerGrid).withComment(INNER_COMMENT).createPanel();
-        panel.setBorder(IdeBorderFactory.createTitledBorder(MessageBundle.message("ui.settings.group.runtime")));
-        JPanel maxArraySize = UI.PanelFactory.panel(myMaxArraySize)
-                .withLabel(MessageBundle.message("ui.setting.label.size"))
-                .withComment(MessageBundle.message("ui.settings.comment.size")).createPanel();
-        maxArraySize.setBorder(IdeBorderFactory.createTitledBorder(MessageBundle.message("ui.settings.group.dynamic")));
+        JPanel maxArraySizePanel = FormBuilder.createFormBuilder()
+                .addLabeledComponent(new JBLabel("Max array size:"), myMaxArraySize, 1)
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + MessageBundle.message("ui.settings.comment.size") + "</div></html>"))
+                .getPanel();
+
+        maxArraySizePanel.setBorder(IdeBorderFactory.createTitledBorder(MessageBundle.message("ui.settings.group.dynamic")));
         myMainPanel = FormBuilder.createFormBuilder()
-                .addComponent(panel)
-                .addComponent(maxArraySize)
+                .addComponent(innerGrid)
+                .addComponent(maxArraySizePanel)
                 .addComponentFillVertically(new JPanel(), 0)
                 .getPanel();
     }

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -30,12 +30,12 @@ inspection.traps.tryCatch=TornadoVM: TornadoVM does not support for Traps/Except
 inspection.traps.throws=TornadoVM: Incompatible thrown types Exception in functional expression
 
 # ui
-ui.settings.comment.env=<p>The environment variable file for TornadoVM is usually \"TornadoVM/setvars.sh\". \
-  This file allows the plugin to call your host's TornadoVM for further analysis of Tornado methods.</p>
-ui.settings.comment.size=<p>Max array size specifies the length of Java variables when automatically initialized \
+ui.settings.comment.env=The environment variable file for TornadoVM is usually \"TornadoVM/setvars.sh\". \
+  This file allows the plugin to call your host's TornadoVM for further analysis of Tornado methods.
+ui.settings.comment.size=Max array size specifies the length of Java variables when automatically initialized \
   by TornadoInsight. For example, when the parameter size is set to 32, and the type of a \
   parameter in a TornadoVM task is IntArray, it will It initialises an IntArray of length 32 \
-  and fills it with random values.</p>
+  and fills it with random values.
 ui.settings.label.tornado=TornadoVM root:
 ui.settings.label.java=Path to Java 21:
 ui.setting.label.size=Max array size:


### PR DESCRIPTION
This PR is used to resolve IntelliJ IDEA 2024.1.* compatibility problems.

## 1. Compatibility with version 241 ## 

![image](https://github.com/beehive-lab/tornado-insight/assets/87227500/351e33ee-8756-4b25-a1ee-d7c69f77b906)

**Problem:**  Plugin is not compatible with version 241 as it requires version 233 or older.
**Solution:** The untilBuild variable in build.grade.kts is changed from "233.\*" to "241.\*"

## 2. Deprecated API Usages ## 

`Deprecated method com.intellij.util.ui.UI.PanelFactory.panel(javax.swing.JComponent component) : com.intellij.openapi.ui.panel.ComponentPanelBuilder is invoked in uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingsComponent.<init>()
Deprecated class com.intellij.openapi.ui.panel.PanelGridBuilder is referenced in uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingsComponent.<init>()
Deprecated method com.intellij.util.ui.UI.PanelFactory.grid() : com.intellij.openapi.ui.panel.PanelGridBuilder is invoked in uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingsComponent.<init>()
Deprecated class com.intellij.openapi.ui.panel.ComponentPanelBuilder is referenced in uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingsComponent.<init>()`

**Problem:**  Deprecated APIs were used for building the settings panel in TornadoSettingsComponent.java
**Solution:** util.ui.UI.PanelFactory and its related methods were replaced with the newer util.ui.FormBuilder.