### PR TITLE
Fixed bugs in dynamic and static checking

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -62,6 +62,7 @@ public class VariableInit {
                     "Double2", "Double3", "Double4", "Double8",
                     "Float2", "Float3", "Float4", "Float8"-> tupleInit(type);
             case "IntArray" -> "= new IntArray(" + size + ");" + name + ".init(" + generateValueByType("Int") + ");";
+            case "ShortArray" -> "= new ShortArray(" + size + ");" + name + ".init((short)" + generateValueByType("Short") + ");";
             case "DoubleArray" ->
                     "= new DoubleArray(" + size + ");" + name + ".init(" + generateValueByType("Double") + ");";
             case "FloatArray" ->
@@ -108,7 +109,7 @@ public class VariableInit {
         return "=new " + type + "(" + parameterSize + "," + parameterSize + ");" +
                 "for (int i = 0; i <" + parameterSize + "; i++) { " +
                 "for (int j = 0; j < " + parameterSize + "; j++) {" +
-                name + ".set(i, j, " + generateValueByType(type.split("Matrix2D")[1]) + ")" +
+                name + ".set(i, j, " + generateValueByType(type.split("Matrix2D")[1]) + ");" +
                 "}" +
                 "}";
     }
@@ -131,7 +132,7 @@ public class VariableInit {
     private static String generateValueByType(String type){
         Random r = new Random();
         return switch (type) {
-            case "Int","int" -> "" + r.nextInt(1000);
+            case "Int", "int", "Short", "short" -> "" + r.nextInt(1000);
             case "Float","float" -> r.nextFloat(1000) + "f";
             case "Double","double" -> "" + r.nextDouble(1000);
             case "Byte","byte" -> "(byte)" + r.nextInt(127);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ExternalLibraryInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ExternalLibraryInspection.java
@@ -69,8 +69,9 @@ public class ExternalLibraryInspection extends AbstractBaseJavaLocalInspectionTo
                                 if (calledMethod != null){
                                     String qualifiedName = Objects.requireNonNull(calledMethod.getContainingClass()).getQualifiedName();
                                     if (qualifiedName != null && !qualifiedName.startsWith("java.") &&
-                                            !qualifiedName.startsWith("uk.ac.manchester.tornado.api")&&
-                                            !qualifiedName.startsWith("_Dummy_")) {
+                                            !qualifiedName.startsWith("uk.ac.manchester.tornado")&&
+                                            !qualifiedName.startsWith("_Dummy_"))
+                                    {
                                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), method);
                                         holder.registerProblem(expression,
                                                 MessageBundle.message("inspection.externalLibrary"),


### PR DESCRIPTION
This PR fixes bugs in TornadoInsight's dynamic and static checking abilities.

## 1. Bug in Code Generation for ShortArray

**Problem:**  Lossy conversion from int to short.
**Solution:**  The value is first generated as an int and then casted into a short in the generated code.

## 2. Typo in creation of matrix2DInit

**Problem:**  A semicolon is missing from the code.
**Solution:**  Semicolon is added.

## 3. Bug in External Library Inspection for static checking

**Problem:** Inspection didn't accept classes from compute examples, and prevented the method from showing up in TornadoInsight side panel.
**Solution:** Inspection now accepts all classes from uk.ac.manchester.tornado.
