### PR TITLE
Fixed problems with code generation for dynamic inspection

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -38,8 +38,7 @@ public class CodeGenerator {
         File dir = FileUtilRt.createTempDirectory("files", null);
         for (PsiMethod method : methods) {
             String fileName = method.getName() + RandomStringUtils.randomAlphanumeric(5);
-            File file = creatFile(project, method, importCodeBlock, fileName, dir);
-            File file = creatFile(project, method, others, importCodeBlock, fileName, dir, psiFile);
+            File file = creatFile(project, method, others, fields, importCodeBlock, fileName, dir);
             methodFile.put(file.getAbsolutePath(), method);
         }
         ExecutionEngine executionEngine = new ExecutionEngine(project, dir.getAbsolutePath(), methodFile);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -22,7 +22,6 @@ import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameter;
 import uk.ac.manchester.beehive.tornado.plugins.util.MessageUtils;
-import uk.ac.manchester.beehive.tornado.plugins.util.MethodUtil;
 import org.apache.commons.lang3.RandomStringUtils;
 
 import java.io.BufferedWriter;
@@ -31,11 +30,10 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import com.intellij.psi.PsiFile;
-
+import java.util.Map;
 public class CodeGenerator {
 
-    public static void fileCreationHandler(Project project, ArrayList<PsiMethod> methods, ArrayList<PsiMethod> others, String importCodeBlock, PsiFile psiFile) throws IOException {
+    public static void fileCreationHandler(Project project, ArrayList<PsiMethod> methods, ArrayList<PsiMethod> others, Map<String, Object> fields, String importCodeBlock) throws IOException {
         HashMap<String, PsiMethod> methodFile = new HashMap<>();
         File dir = FileUtilRt.createTempDirectory("files", null);
         for (PsiMethod method : methods) {
@@ -48,7 +46,7 @@ public class CodeGenerator {
         executionEngine.run();
     }
 
-    private static File creatFile(Project project, PsiMethod method, ArrayList<PsiMethod> others, String importCodeBlock, String filename, File dir, PsiFile psiFile) {
+    private static File creatFile(Project project, PsiMethod method, ArrayList<PsiMethod> others, Map<String, Object> fields, String importCodeBlock, String filename, File dir) {
         File javaFile;
         try {
             javaFile = FileUtilRt.createTempFile(dir, filename, ".java", true);
@@ -87,13 +85,18 @@ public class CodeGenerator {
             bufferedWriter.write("\n");
             bufferedWriter.write("public class " + javaFile.getName().replace(".java", "") + "{");
             bufferedWriter.write("\n");
+            for (Map.Entry<String, Object> field: fields.entrySet()) {
+                bufferedWriter.write(field.getKey());
+                if (field.getValue() != null) {
+                    bufferedWriter.write(" = "+ field.getValue());
+                }
+                bufferedWriter.write("; \n");
+            }
             bufferedWriter.write(method.getText());
             for (PsiMethod other: others) {
                 String methodText = other.getText();
-                if (!other.getText().contains("TaskGraph")) {
-                    bufferedWriter.write(methodText);
-                    bufferedWriter.write("\n");
-                }
+                bufferedWriter.write(methodText);
+                bufferedWriter.write("\n");
             }
 
             bufferedWriter.write(mainCode);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -23,6 +23,7 @@ import com.intellij.psi.PsiMethod;
 import com.intellij.psi.PsiParameter;
 import uk.ac.manchester.beehive.tornado.plugins.util.MessageUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import uk.ac.manchester.beehive.tornado.plugins.util.TornadoTWTask;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -30,22 +31,27 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 public class CodeGenerator {
 
-    public static void fileCreationHandler(Project project, ArrayList<PsiMethod> methods, ArrayList<PsiMethod> others, Map<String, Object> fields, String importCodeBlock) throws IOException {
+    public static void fileCreationHandler(Project project, List<String> data) throws IOException {
         HashMap<String, PsiMethod> methodFile = new HashMap<>();
+        ArrayList<PsiMethod> methods = TornadoTWTask.getMethods(data);
+        ArrayList<PsiMethod> others = TornadoTWTask.getCalledMethods(methods);
+        Map<String, Object> fields = TornadoTWTask.getFields();
+        String importCodeBlock = TornadoTWTask.getImportCodeBlock();
         File dir = FileUtilRt.createTempDirectory("files", null);
         for (PsiMethod method : methods) {
             String fileName = method.getName() + RandomStringUtils.randomAlphanumeric(5);
-            File file = creatFile(project, method, others, fields, importCodeBlock, fileName, dir);
+            File file = createFile(project, method, others, fields, importCodeBlock, fileName, dir);
             methodFile.put(file.getAbsolutePath(), method);
         }
         ExecutionEngine executionEngine = new ExecutionEngine(project, dir.getAbsolutePath(), methodFile);
         executionEngine.run();
     }
 
-    private static File creatFile(Project project, PsiMethod method, ArrayList<PsiMethod> others, Map<String, Object> fields, String importCodeBlock, String filename, File dir) {
+    private static File createFile(Project project, PsiMethod method, ArrayList<PsiMethod> others, Map<String, Object> fields, String importCodeBlock, String filename, File dir) {
         File javaFile;
         try {
             javaFile = FileUtilRt.createTempFile(dir, filename, ".java", true);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
@@ -18,17 +18,14 @@
 package uk.ac.manchester.beehive.tornado.plugins.dynamicInspection;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiMethod;
-import uk.ac.manchester.beehive.tornado.plugins.util.TornadoTWTask;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.List;
 
 public class DynamicInspection {
-    public static void process(Project project, ArrayList<PsiMethod> methodArrayList, ArrayList<PsiMethod> others, Map<String, Object> fields){
+    public static void process(Project project, List<String> data){
         try {
-            CodeGenerator.fileCreationHandler(project, methodArrayList, others, fields, TornadoTWTask.getImportCodeBlock());
+            CodeGenerator.fileCreationHandler(project, data);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
@@ -18,6 +18,7 @@
 package uk.ac.manchester.beehive.tornado.plugins.dynamicInspection;
 
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import uk.ac.manchester.beehive.tornado.plugins.util.TornadoTWTask;
 
@@ -25,9 +26,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public class DynamicInspection {
-    public static void process(Project project, ArrayList<PsiMethod> methodArrayList){
+    public static void process(Project project, ArrayList<PsiMethod> methodArrayList, ArrayList<PsiMethod> others, PsiFile psiFile){
         try {
-            CodeGenerator.fileCreationHandler(project,methodArrayList, TornadoTWTask.getImportCodeBlock());
+            CodeGenerator.fileCreationHandler(project, methodArrayList, others, TornadoTWTask.getImportCodeBlock(), psiFile);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/DynamicInspection.java
@@ -18,17 +18,17 @@
 package uk.ac.manchester.beehive.tornado.plugins.dynamicInspection;
 
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiMethod;
 import uk.ac.manchester.beehive.tornado.plugins.util.TornadoTWTask;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Map;
 
 public class DynamicInspection {
-    public static void process(Project project, ArrayList<PsiMethod> methodArrayList, ArrayList<PsiMethod> others, PsiFile psiFile){
+    public static void process(Project project, ArrayList<PsiMethod> methodArrayList, ArrayList<PsiMethod> others, Map<String, Object> fields){
         try {
-            CodeGenerator.fileCreationHandler(project, methodArrayList, others, TornadoTWTask.getImportCodeBlock(), psiFile);
+            CodeGenerator.fileCreationHandler(project, methodArrayList, others, fields, TornadoTWTask.getImportCodeBlock());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
@@ -21,15 +21,12 @@ import com.intellij.openapi.actionSystem.ActionUpdateThread;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.PsiMethod;
 import uk.ac.manchester.beehive.tornado.plugins.dynamicInspection.DynamicInspection;
 import uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingState;
 import uk.ac.manchester.beehive.tornado.plugins.ui.toolwindow.EmptySelectionWarningDialog;
 import uk.ac.manchester.beehive.tornado.plugins.util.DataKeys;
-import uk.ac.manchester.beehive.tornado.plugins.util.TornadoTWTask;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class RunInspectionAction extends AnAction {
@@ -40,8 +37,7 @@ public class RunInspectionAction extends AnAction {
         if (data.isEmpty()) {
             new EmptySelectionWarningDialog().show();
         }else {
-            ArrayList<PsiMethod> methods = TornadoTWTask.getMethods(data);
-            DynamicInspection.process(e.getProject(), methods, TornadoTWTask.getCalledMethods(methods), TornadoTWTask.getFields());
+            DynamicInspection.process(e.getProject(), data);
         }
     }
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
@@ -41,7 +41,7 @@ public class RunInspectionAction extends AnAction {
             new EmptySelectionWarningDialog().show();
         }else {
             ArrayList<PsiMethod> methods = TornadoTWTask.getMethods(data);
-            DynamicInspection.process(e.getProject(), methods, TornadoTWTask.getOtherMethods(methods), TornadoTWTask.getFile());
+            DynamicInspection.process(e.getProject(), methods, TornadoTWTask.getCalledMethods(methods), TornadoTWTask.getFields());
         }
     }
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/service/RunInspectionAction.java
@@ -41,7 +41,7 @@ public class RunInspectionAction extends AnAction {
             new EmptySelectionWarningDialog().show();
         }else {
             ArrayList<PsiMethod> methods = TornadoTWTask.getMethods(data);
-            DynamicInspection.process(e.getProject(), methods);
+            DynamicInspection.process(e.getProject(), methods, TornadoTWTask.getOtherMethods(methods), TornadoTWTask.getFile());
         }
     }
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
@@ -40,6 +40,7 @@ public class TornadoTWTask {
     private static List<PsiMethod> taskList;
     private static String importCodeBlock;
     private static Map<String, PsiMethod> taskMap;
+    private static PsiFile psiFile;
 
     /**
      * Adds TornadoVM Tasks to the given UI data model.
@@ -53,6 +54,7 @@ public class TornadoTWTask {
         taskList = new ArrayList<>();
         taskMap = new HashMap<>();
         PsiFile file = PsiManager.getInstance(project).findFile(virtualFile);
+        psiFile = file;
         assert file != null;
         importCodeBlock = getImportCode(file);
         taskList = findAnnotatedVariables(file);
@@ -66,6 +68,13 @@ public class TornadoTWTask {
         }
     }
 
+    public static ArrayList<PsiMethod> getOtherMethods(ArrayList<PsiMethod> otherMethods) {
+        Collection<PsiMethod> allMethods = PsiTreeUtil.findChildrenOfType(psiFile, PsiMethod.class);
+        ArrayList<PsiMethod> allMethodsList = new ArrayList<>(allMethods);
+        allMethodsList.removeAll(otherMethods);
+        allMethodsList.removeIf(method -> "main".equals(method.getName()));
+        return allMethodsList;
+    }
     /**
      * Finds methods in the given PsiFile that are annotated with TornadoVM related annotations.
      *
@@ -156,5 +165,9 @@ public class TornadoTWTask {
      */
     public static String getImportCodeBlock() {
         return importCodeBlock;
+    }
+
+    public static PsiFile getFile() {
+        return psiFile;
     }
 }


### PR DESCRIPTION
This PR fixes issues with code generation for dynamic inspection.

## 1. Helper methods not defined in the generated code.

**Problem:**  Since the generated code only involved the method that was run with TornadoInsight, any calls to other methods caused an error.
**Solution:**  Using a recursive approach, the helper methods called within the primary method are identified and added to the generated code.
**Testing:** This fix can be tested by running dynamic inspection on BlackScholes.java, which has a call to a helper method within the class.

## 2. Class variables not defined in the generated code.

**Problem:**  Class variables were not defined in the generated code.
**Solution:**  Type, modifier, name, and value of class variables are identified and used to define them in the generated code.
**Testing:** This fix can be tested by running dynamic inspection on BFS.java, which has several class variables used by the primary method.