### PR TITLE
Added support for new types

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
@@ -102,7 +102,8 @@ public class ExecutionEngine {
         commandLine.addParameter("-g");
         commandLine.addParameter("-classpath");
         commandLine.addParameter(TornadoSettingState.getInstance().getApiPath()+
-                File.pathSeparator + TornadoSettingState.getInstance().getMatricesPath()) ;
+                File.pathSeparator + TornadoSettingState.getInstance().getMatricesPath()+
+                File.pathSeparator + TornadoSettingState.getInstance().getUnitTestPath());
         commandLine.addParameter("-d");
         commandLine.addParameter(outputDir);
         commandLine.addParameters(javaFiles);  // Adds each Java file to the command line

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -44,6 +44,7 @@ public class VariableInit {
         StringBuilder returnString = new StringBuilder();
         int size = parametersName.size();
         for (int i = 0; i < size; i++) {
+            returnString.append("\t\t");
             returnString.append(parametersType.get(i)).append(" ").append(parametersName.get(i));
             String value = lookupBoxedTypes(parametersType.get(i), parametersName.get(i), parameterSize);
             returnString.append(value);
@@ -71,6 +72,14 @@ public class VariableInit {
                     "= new DoubleArray(" + size + ");" + name + ".init(" + generateValueByType("Double") + ");";
             case "FloatArray" ->
                     "= new FloatArray(" + size + ");" + name + ".init(" + generateValueByType("Float") + ");";
+            case "HalfFloatArray" ->
+                    "= new HalfFloatArray(" + size + ");" + name + ".init(new HalfFloat(" + generateValueByType("HalfFloat") + "));";
+            case "CharArray" ->
+                    "= new CharArray(" + size + ");" + name + ".init(" + generateValueByType("Char") + ");";
+            case "ByteArray" ->
+                    "= new ByteArray(" + size + ");" + name + ".init(" + generateValueByType("Byte") + ");";
+            case "LongArray" ->
+                    "= new LongArray(" + size + ");" + name + ".init(" + generateValueByType("Long") + ");";
             case "Matrix2DFloat", "Matrix2DFloat4", "Matrix2DDouble", "Matrix2DInt" -> matrix2DInit(type, name);
             case "Matrix3DFloat", "Matrix3DFloat4", "Matrix" -> matrix3DInit(type, name, "Float");
             case "ImageByte3", "ImageByte4" -> imageInit(type,name, "Byte");
@@ -143,9 +152,11 @@ public class VariableInit {
         Random r = new Random();
         return switch (type) {
             case "Int", "int", "Short", "short" -> "" + r.nextInt(1000);
+            case "Long", "long" -> "" + r.nextLong(1000);
             case "Float","float", "HalfFloat" -> r.nextFloat(1000) + "f";
             case "Double","double" -> "" + r.nextDouble(1000);
             case "Byte","byte" -> "(byte)" + r.nextInt(127);
+            case "Char", "char" -> "'" + (char)(r.nextInt(26) + 'a') + "'";
             default -> "";
         };
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -47,6 +47,7 @@ public class VariableInit {
             returnString.append(parametersType.get(i)).append(" ").append(parametersName.get(i));
             String value = lookupBoxedTypes(parametersType.get(i), parametersName.get(i), parameterSize);
             returnString.append(value);
+            returnString.append("\n");
         }
         return returnString.toString();
     }
@@ -98,7 +99,7 @@ public class VariableInit {
         int size = type.charAt(type.length()-1) - '0';
         System.out.println(primitiveType);
         StringBuilder builder = new StringBuilder();
-        builder.append("=new ").append(type).append("(");
+        builder.append(" = new ").append(type).append("(");
         builder.append(generateValueByType(primitiveType));
         for (int i = 0; i < size - 1; i++){
             builder.append(",");
@@ -110,26 +111,26 @@ public class VariableInit {
     }
 
     private static String matrix2DInit(String type, String name){
-        return "=new " + type + "(" + parameterSize + "," + parameterSize + ");" +
+        return " = new " + type + "(" + parameterSize + "," + parameterSize + ");" +
                 "for (int i = 0; i <" + parameterSize + "; i++) { " +
-                "for (int j = 0; j < " + parameterSize + "; j++) {" +
+                "for (int j = 0; j < " + parameterSize + "; j++) {" + "\n" +
                 name + ".set(i, j, " + generateValueByType(type.split("Matrix2D")[1]) + ");" +
                 "}" +
                 "}";
     }
 
     private static String matrix3DInit(String type, String name, String primitive){
-        return "=new " + type + "(" + parameterSize + "," + parameterSize + "," + parameterSize + ");" +
+        return " = new " + type + "(" + parameterSize + "," + parameterSize + "," + parameterSize + ");" + "\n" +
                 name  + ".fill(" + generateValueByType(primitive) + ");";
     }
 
     private static String imageInit(String type, String name, String primitive){
-        return "=new " + type + "(" + parameterSize + "," + parameterSize + ");" +
+        return " = new " + type + "(" + parameterSize + "," + parameterSize + ");" + "\n" +
                 name + ".fill(" + generateValueByType(primitive) + ");";
     }
 
     private static String vectorIntInit(String name, String type, String innerType){
-        return "=new " + type + "(" + parameterSize + ");" +
+        return " = new " + type + "(" + parameterSize + ");" + "\n" +
                 name + ".fill(" + generateValueByType(innerType) + ");";
     }
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -78,7 +78,7 @@ public class VariableInit {
             case "VectorInt", "VectorInt2", "VectorInt3", "VectorInt4", "VectorInt8", "VectorInt16" -> vectorIntInit(name, type, "Int");
             case "VectorFloat", "VectorFloat2", "VectorFloat3", "VectorFloat4", "VectorFloat8", "VectorFloat16" -> vectorIntInit(name, type, "Float");
             case "VectorDouble", "VectorDouble2", "VectorDouble3", "VectorDouble4", "VectorDouble8", "VectorDouble16" -> vectorIntInit(name, type, "Double");
-            case "VectorHalf", "VectorHalf2", "VectorHalf3", "VectorHalf4", "VectorHalf8", "VectorHalf16" -> vectorIntInit(name, type, "HalfFloat");
+            case "VectorHalf", "VectorHalf2", "VectorHalf3", "VectorHalf4", "VectorHalf8", "VectorHalf16" -> vectorHalfIntInit(name, type);
             default -> "";
         };
     }
@@ -132,6 +132,11 @@ public class VariableInit {
     private static String vectorIntInit(String name, String type, String innerType){
         return " = new " + type + "(" + parameterSize + ");" + "\n" +
                 name + ".fill(" + generateValueByType(innerType) + ");";
+    }
+
+    private static String vectorHalfIntInit(String name, String type){
+        return " = new " + type + "(" + parameterSize + ");" + "\n" +
+                name + ".fill(new HalfFloat(" + generateValueByType("HalfFloat") + "));";
     }
 
     private static String generateValueByType(String type){

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -58,23 +58,26 @@ public class VariableInit {
             case "double" -> "=" + generateValueByType("Double") + ";";
             case "HalfFloat" -> "= new HalfFloat(" + generateValueByType("HalfFloat") + ");";
             case "int[]", "float[]", "double[]", "byte[]" -> arrayInit(type);
-            case "Int2", "Int3", "Int4", "Int8",
+            case "Int2", "Int3", "Int4", "Int8", "Int16",
                     "Byte2", "Byte3", "Byte4", "Byte8",
-                    "Double2", "Double3", "Double4", "Double8",
-                    "Float2", "Float3", "Float4", "Float8"-> tupleInit(type);
+                    "Double2", "Double3", "Double4", "Double8", "Double16",
+                    "Float2", "Float3", "Float4", "Float8", "Float16",
+                    "Half2", "Half3", "Half4", "Half8", "Half16",
+                    "Short2", "Short3" -> tupleInit(type);
             case "IntArray" -> "= new IntArray(" + size + ");" + name + ".init(" + generateValueByType("Int") + ");";
             case "ShortArray" -> "= new ShortArray(" + size + ");" + name + ".init((short)" + generateValueByType("Short") + ");";
             case "DoubleArray" ->
                     "= new DoubleArray(" + size + ");" + name + ".init(" + generateValueByType("Double") + ");";
             case "FloatArray" ->
                     "= new FloatArray(" + size + ");" + name + ".init(" + generateValueByType("Float") + ");";
-            case "Matrix2DFloat", "Matrix2DDouble", "Matrix2DInt" -> matrix2DInit(type, name);
+            case "Matrix2DFloat", "Matrix2DFloat4", "Matrix2DDouble", "Matrix2DInt" -> matrix2DInit(type, name);
             case "Matrix3DFloat", "Matrix3DFloat4", "Matrix" -> matrix3DInit(type, name, "Float");
             case "ImageByte3", "ImageByte4" -> imageInit(type,name, "Byte");
             case "ImageFloat", "ImageFloat3", "ImageFloat4", "ImageFloat8" -> imageInit(type, name, "Float");
-            case "VectorInt", "VectorInt4", "VectorInt3", "VectorInt8", "VectorInt2" -> vectorIntInit(name, type, "Int");
-            case "VectorFloat", "VectorFloat4", "VectorFloat3", "VectorFloat8", "VectorFloat2" -> vectorIntInit(name, type, "Float");
-            case "VectorDouble", "VectorDouble4", "VectorDouble3", "VectorDouble8", "VectorDouble2" -> vectorIntInit(name, type, "Double");
+            case "VectorInt", "VectorInt2", "VectorInt3", "VectorInt4", "VectorInt8", "VectorInt16" -> vectorIntInit(name, type, "Int");
+            case "VectorFloat", "VectorFloat2", "VectorFloat3", "VectorFloat4", "VectorFloat8", "VectorFloat16" -> vectorIntInit(name, type, "Float");
+            case "VectorDouble", "VectorDouble2", "VectorDouble3", "VectorDouble4", "VectorDouble8", "VectorDouble16" -> vectorIntInit(name, type, "Double");
+            case "VectorHalf", "VectorHalf2", "VectorHalf3", "VectorHalf4", "VectorHalf8", "VectorHalf16" -> vectorIntInit(name, type, "HalfFloat");
             default -> "";
         };
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -56,6 +56,7 @@ public class VariableInit {
             case "int" -> "=" + generateValueByType("Int") + ";";
             case "float" -> "=" + generateValueByType("Float") + ";";
             case "double" -> "=" + generateValueByType("Double") + ";";
+            case "HalfFloat" -> "= new HalfFloat(" + generateValueByType("HalfFloat") + ");";
             case "int[]", "float[]", "double[]", "byte[]" -> arrayInit(type);
             case "Int2", "Int3", "Int4", "Int8",
                     "Byte2", "Byte3", "Byte4", "Byte8",
@@ -133,7 +134,7 @@ public class VariableInit {
         Random r = new Random();
         return switch (type) {
             case "Int", "int", "Short", "short" -> "" + r.nextInt(1000);
-            case "Float","float" -> r.nextFloat(1000) + "f";
+            case "Float","float", "HalfFloat" -> r.nextFloat(1000) + "f";
             case "Double","double" -> "" + r.nextDouble(1000);
             case "Byte","byte" -> "(byte)" + r.nextInt(127);
             default -> "";

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
@@ -86,5 +86,9 @@ public class TornadoSettingState implements PersistentStateComponent<TornadoSett
         return TornadoRoot + "/tornado-api/target/classes";
     }
 
+    public String getUnitTestPath(){
+        return TornadoRoot + "/tornado-unittests/target/classes";
+    }
+
     public String getJavaHome(){return JdkPath.getHomePath();}
 }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
@@ -205,7 +205,9 @@ public class TornadoTWTask {
         if (importList != null) {
             PsiImportStatement[] importStatements = importList.getImportStatements();
             for (PsiImportStatement importStatement : importStatements) {
-                importCodeBlock.append(importStatement.getText()).append("\n");
+                if (!importStatement.getText().equals("import org.junit.Test;")) {
+                    importCodeBlock.append(importStatement.getText()).append("\n");
+                }
             }
         }
         return importCodeBlock.toString();


### PR DESCRIPTION
This PR adds support for the TornadoVM types that were previously not supported by TornadoInsight.

## Feature

The list of types that are now supported in TornadoInsight is below.

1. HalfFloat
2. HalfFloatArray
3. CharArray
4. ByteArray
5. LongArray
6. Matrix2DFloat, Matrix2DFloat4, Matrix2DDouble, Matrix2DInt
7. Int16
8. Double16
9. Half2, Half3, Half4, Half8, Half16
10. Short2, Short3
11. VectorInt16
12. VectorFloat16
13. VectorDouble16
14. VectorHalf16

## Testing

This feature can be tested by running dynamic inspection on tasks inside the files `TestArrays.java` and `TestHalfFloats.java`