### PR TITLE
[feat] Support for TornadoVM Tensor types

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -174,7 +174,9 @@ public class VariableInit {
         int[] numbers = new int[stringArray.length];
 
         for (int i = 0; i < stringArray.length; i++) {
-            numbers[i] = Integer.parseInt(stringArray[i].trim());
+            if (!stringArray[i].trim().isEmpty()) {
+                numbers[i] = Integer.parseInt(stringArray[i].trim());
+            }
         }
         return numbers;
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -28,9 +28,12 @@ import java.util.Random;
 public class VariableInit {
 
     public static int parameterSize;
+    public static int[] tensorShapeDimensions;
 
     public static String variableInitHelper(@NotNull PsiMethod method) {
         parameterSize = TornadoSettingState.getInstance().parameterSize;
+        tensorShapeDimensions = TornadoSettingState.getInstance().tensorShapeDimensions;
+
         ArrayList<String> parametersName = new ArrayList<>();
         ArrayList<String> parametersType = new ArrayList<>();
         for (PsiParameter parameter : method.getParameterList().getParameters()) {
@@ -89,6 +92,7 @@ public class VariableInit {
             case "VectorDouble", "VectorDouble2", "VectorDouble3", "VectorDouble4", "VectorDouble8", "VectorDouble16" -> vectorInit(name, type, "Double");
             case "VectorHalf", "VectorHalf2", "VectorHalf3", "VectorHalf4", "VectorHalf8", "VectorHalf16" -> vectorHalfInit(name, type);
             case "KernelContext" -> " = new KernelContext();";
+            case "TensorByte", "TensorFP16", "TensorFP32", "TensorFP64", "TensorInt16", "TensorInt32", "TensorInt64" -> tensorInit(type);
             default -> "";
         };
     }
@@ -147,6 +151,19 @@ public class VariableInit {
     private static String vectorHalfInit(String name, String type){
         return " = new " + type + "(" + parameterSize + ");" + "\n" +
                 name + ".fill(new HalfFloat(" + generateValueByType("HalfFloat") + "));";
+    }
+
+    private static String tensorInit(String type){
+        StringBuilder builder = new StringBuilder();
+        builder.append(" = new ").append(type).append("(").append("new Shape(");
+        for (int i = 0; i < tensorShapeDimensions.length; i++){
+            builder.append(tensorShapeDimensions[i]);
+            if (i < tensorShapeDimensions.length - 1){
+                builder.append(", ");
+            }
+        }
+        builder.append("));").append("\n");
+        return builder.toString();
     }
 
     private static String generateValueByType(String type){

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -27,12 +27,14 @@ import java.util.Random;
 
 public class VariableInit {
 
-    public static int parameterSize;
-    public static int[] tensorShapeDimensions;
+    private static int parameterSize;
+    private static String tensorShapeDimension;
+    private static int[] tensorShapeDimensions;
 
     public static String variableInitHelper(@NotNull PsiMethod method) {
         parameterSize = TornadoSettingState.getInstance().parameterSize;
-        tensorShapeDimensions = TornadoSettingState.getInstance().tensorShapeDimensions;
+        tensorShapeDimension = TornadoSettingState.getInstance().tensorShapeDimensions;
+        tensorShapeDimensions = convertShapeStringToIntArray(tensorShapeDimension);
 
         ArrayList<String> parametersName = new ArrayList<>();
         ArrayList<String> parametersType = new ArrayList<>();
@@ -156,6 +158,7 @@ public class VariableInit {
     private static String tensorInit(String type){
         StringBuilder builder = new StringBuilder();
         builder.append(" = new ").append(type).append("(").append("new Shape(");
+
         for (int i = 0; i < tensorShapeDimensions.length; i++){
             builder.append(tensorShapeDimensions[i]);
             if (i < tensorShapeDimensions.length - 1){
@@ -164,6 +167,16 @@ public class VariableInit {
         }
         builder.append("));").append("\n");
         return builder.toString();
+    }
+
+    private static int[] convertShapeStringToIntArray(String shapeString){
+        String[] stringArray = shapeString.split(",");
+        int[] numbers = new int[stringArray.length];
+
+        for (int i = 0; i < stringArray.length; i++) {
+            numbers[i] = Integer.parseInt(stringArray[i].trim());
+        }
+        return numbers;
     }
 
     private static String generateValueByType(String type){

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingConfiguration.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingConfiguration.java
@@ -57,6 +57,8 @@ public class TornadoSettingConfiguration implements Configurable {
         boolean modified = !mySettingsComponent.getJdk().equals(settings.JdkPath);
         modified |= !mySettingsComponent.getTornadoEnvPath().equals(settings.TornadoRoot);
         modified |= mySettingsComponent.getMaxArraySize() != settings.parameterSize;
+        modified |= mySettingsComponent.getTensorShapeDimension() != settings.tensorShapeDimension;
+        modified |= mySettingsComponent.getTensorShapeDimensionSizes() != settings.tensorShapeDimensions;
         modified |= mySettingsComponent.isSaveFileEnabled() != settings.saveFileEnabled;
         modified |= !mySettingsComponent.getFileSaveLocation().equals(settings.fileSaveLocation);
         return modified;
@@ -74,6 +76,8 @@ public class TornadoSettingConfiguration implements Configurable {
         settings.TornadoRoot = mySettingsComponent.getTornadoEnvPath();
         settings.JdkPath = mySettingsComponent.getJdk();
         settings.parameterSize = mySettingsComponent.getMaxArraySize();
+        settings.tensorShapeDimension = mySettingsComponent.getTensorShapeDimension();
+        settings.tensorShapeDimensions = mySettingsComponent.getTensorShapeDimensionSizes();
         settings.saveFileEnabled = mySettingsComponent.isSaveFileEnabled();
         settings.fileSaveLocation = mySettingsComponent.getFileSaveLocation();
     }
@@ -85,6 +89,8 @@ public class TornadoSettingConfiguration implements Configurable {
         mySettingsComponent.setTornadoEnvPath(settings.TornadoRoot);
         mySettingsComponent.setMyJdk(settings.JdkPath);
         mySettingsComponent.setMaxArraySize(settings.parameterSize);
+        mySettingsComponent.setTensorShapeDimension(settings.tensorShapeDimension);
+        mySettingsComponent.setTensorShapeDimensionSizes(settings.tensorShapeDimensions);
         mySettingsComponent.setSaveFileEnabled(settings.saveFileEnabled);
         mySettingsComponent.setFileSaveLocation(settings.fileSaveLocation);
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingConfiguration.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingConfiguration.java
@@ -57,8 +57,7 @@ public class TornadoSettingConfiguration implements Configurable {
         boolean modified = !mySettingsComponent.getJdk().equals(settings.JdkPath);
         modified |= !mySettingsComponent.getTornadoEnvPath().equals(settings.TornadoRoot);
         modified |= mySettingsComponent.getMaxArraySize() != settings.parameterSize;
-        modified |= mySettingsComponent.getTensorShapeDimension() != settings.tensorShapeDimension;
-        modified |= mySettingsComponent.getTensorShapeDimensionSizes() != settings.tensorShapeDimensions;
+        modified |= mySettingsComponent.getTensorShapeDimensions() != settings.tensorShapeDimensions;
         modified |= mySettingsComponent.isSaveFileEnabled() != settings.saveFileEnabled;
         modified |= !mySettingsComponent.getFileSaveLocation().equals(settings.fileSaveLocation);
         return modified;
@@ -76,8 +75,7 @@ public class TornadoSettingConfiguration implements Configurable {
         settings.TornadoRoot = mySettingsComponent.getTornadoEnvPath();
         settings.JdkPath = mySettingsComponent.getJdk();
         settings.parameterSize = mySettingsComponent.getMaxArraySize();
-        settings.tensorShapeDimension = mySettingsComponent.getTensorShapeDimension();
-        settings.tensorShapeDimensions = mySettingsComponent.getTensorShapeDimensionSizes();
+        settings.tensorShapeDimensions = mySettingsComponent.getTensorShapeDimensions();
         settings.saveFileEnabled = mySettingsComponent.isSaveFileEnabled();
         settings.fileSaveLocation = mySettingsComponent.getFileSaveLocation();
     }
@@ -89,8 +87,7 @@ public class TornadoSettingConfiguration implements Configurable {
         mySettingsComponent.setTornadoEnvPath(settings.TornadoRoot);
         mySettingsComponent.setMyJdk(settings.JdkPath);
         mySettingsComponent.setMaxArraySize(settings.parameterSize);
-        mySettingsComponent.setTensorShapeDimension(settings.tensorShapeDimension);
-        mySettingsComponent.setTensorShapeDimensionSizes(settings.tensorShapeDimensions);
+        mySettingsComponent.setTensorShapeDimensions(settings.tensorShapeDimensions);
         mySettingsComponent.setSaveFileEnabled(settings.saveFileEnabled);
         mySettingsComponent.setFileSaveLocation(settings.fileSaveLocation);
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
@@ -40,8 +40,7 @@ public class TornadoSettingState implements PersistentStateComponent<TornadoSett
     @OptionTag(converter = JdkConverter.class)
     public Sdk JdkPath;
     public int parameterSize;
-    public int tensorShapeDimension;
-    public int[] tensorShapeDimensions;
+    public String tensorShapeDimensions;
     public boolean isValid;
     public boolean saveFileEnabled;
     public String fileSaveLocation;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingState.java
@@ -40,6 +40,8 @@ public class TornadoSettingState implements PersistentStateComponent<TornadoSett
     @OptionTag(converter = JdkConverter.class)
     public Sdk JdkPath;
     public int parameterSize;
+    public int tensorShapeDimension;
+    public int[] tensorShapeDimensions;
     public boolean isValid;
     public boolean saveFileEnabled;
     public String fileSaveLocation;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
@@ -43,7 +43,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
@@ -87,22 +87,22 @@ public class TornadoSettingsComponent {
         JPanel innerGrid = FormBuilder.createFormBuilder()
                 .addLabeledComponent(new JBLabel("TornadoVM Root:"), myTornadoEnv)
                 .addLabeledComponent(new JBLabel("Java SDK:"), myJdk)
-                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + INNER_COMMENT + "</div></html>"))
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray;'>" + INNER_COMMENT + "</div></html>"))
                 .addVerticalGap(10)
                 .getPanel();
 
         JPanel dynamicInspectionPanel = FormBuilder.createFormBuilder()
                 .addLabeledComponent(new JBLabel("Max array size:"), myMaxArraySize, 1)
-                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + MessageBundle.message("ui.settings.max.array.size") + "</div></html>"))
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray;'>" + MessageBundle.message("ui.settings.max.array.size") + "</div></html>"))
                 .addLabeledComponent("Tensor shape dimensions:", tensorShapeDimensions)
-                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + MessageBundle.message("ui.settings.tensor.shape.dimensions.doc") + "</div></html>"))
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray;'>" + MessageBundle.message("ui.settings.tensor.shape.dimensions.doc") + "</div></html>"))
                 .getPanel();
 
         dynamicInspectionPanel.setBorder(IdeBorderFactory.createTitledBorder(MessageBundle.message("ui.settings.group.dynamic")));
 
         JPanel debugPanel = FormBuilder.createFormBuilder()
                 .addComponent(saveFileCheckbox)
-                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray; font-size:15px;'>" + MessageBundle.message("ui.settings.comment.debug.file") + "</div></html>"))
+                .addLabeledComponent(new JBLabel(" "), new JLabel("<html><div style='width:400px; color:gray;'>" + MessageBundle.message("ui.settings.comment.debug.file") + "</div></html>"))
                 .addLabeledComponent(new JBLabel("Save Location:"), fileSaveLocationField)
                 .getPanel();
 

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
@@ -139,6 +139,7 @@ public class TornadoSettingsComponent {
             try {
                 int dimensions = Integer.parseInt(tensorShapeDimension.getText());
                 if (dimensions < 0) { throw new RuntimeException("Dimensions cannot be negative"); }
+                tensorShapeDimensionsSizes.clear();
                 for (int i = 0; i < dimensions; i++) {
                     JBTextField dimensionSizeField = new JBTextField();
                     dynamicTensorsPanel.add(new JLabel("Dimension " + (i + 1) + " size:"));

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/settings/TornadoSettingsComponent.java
@@ -149,7 +149,7 @@ public class TornadoSettingsComponent {
 
     public String getTensorShapeDimensions() {
         if (tensorShapeDimensions.getText().isEmpty() || Objects.equals(tensorShapeDimensions.getText(), "0")) {
-            return "64";
+            return "";
         }
         return tensorShapeDimensions.getText();
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
@@ -216,7 +216,7 @@ public class TornadoTWTask {
             PsiImportStatement[] importStatements = importList.getImportStatements();
             for (PsiImportStatement importStatement : importStatements) {
                 String importText = importStatement.getText();
-                if (isJunit(importText)) {
+                if (statementImportsJunit(importText)) {
                     continue;
                 }
                 importCodeBlock.append(importStatement.getText());
@@ -244,8 +244,8 @@ public class TornadoTWTask {
         return importCodeBlock;
     }
 
-    private static boolean isJunit(String importStatement) {
-        return importStatement.equals("import org.junit.Test;");
+    private static boolean statementImportsJunit(String importStatement) {
+        return importStatement.contains("import org.junit.");
     }
 
 }

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -36,7 +36,7 @@ ui.settings.max.array.size=Max array size specifies the length of Java variables
   by TornadoInsight. For example, when the parameter size is set to 32, and the type of a \
   parameter in a TornadoVM task is IntArray, TornadoInsight creates an IntArray of length 32 \
   and fills it with random values.
-ui.settings.tensor.shape.dimensions.size=Tensor shape dimensions define the rank of a TornadoVM tensor type (i.e, the number of the dimensions of the shape). Once you have defined the number of dimensions click the <b>Set shape</b> button to configure the size of each dimension.
+ui.settings.tensor.shape.dimensions.doc=Tensor shape dimensions define the dimensions of a TornadoVM tensor type as a list of integer values separated by commas.
 ui.settings.comment.debug.file=Saves an internally generated file for debugging purposes. This feature is not intended for regular users.
 ui.settings.label.tornado=TornadoVM root:
 ui.settings.label.java=Path to Java 21:
@@ -46,7 +46,9 @@ ui.settings.group.debugging=Debug options
 ui.settings.group.dynamic=Dynamic Inspection
 ui.settings.validation.emptySize=Empty Parameter size
 ui.settings.validation.invalidSize=Parameter scale needs to be greater than 0 and less than 65534
-ui.settings.validation.shapeSize=Invalid shape size for a tensor. You defined at least one dimension as negative or zero.
+ui.settings.validation.shape.dimensions.negative=Invalid shape for a tensor. You defined at least one dimension as negative.
+ui.settings.validation.shape.dimensions=Invalid shape for a tensor. Please define the shape as a list of integer values separated by commas.
+ui.settings.validation.shape.dimensions.float=Invalid format of a dimension within the shape. Please define the shape as a list of integer values separated by commas.
 ui.settings.validation.emptyTornadovm=Empty TornadoVM path
 ui.settings.validation.emptyJava=Empty Java path
 ui.settings.validation.emptySave=Empty save location

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -36,7 +36,7 @@ ui.settings.max.array.size=Max array size specifies the length of Java variables
   by TornadoInsight. For example, when the parameter size is set to 32, and the type of a \
   parameter in a TornadoVM task is IntArray, TornadoInsight creates an IntArray of length 32 \
   and fills it with random values.
-ui.settings.tensor.shape.dimensions.doc=Tensor shape dimensions define the dimensions of a TornadoVM tensor type as a list of integer values separated by commas.
+ui.settings.tensor.shape.dimensions.doc=Tensor shape dimensions define the dimensions of a TornadoVM tensor type as a list of integer values separated by commas. For example, to set a three-dimensional shape: 16, 1, 1.
 ui.settings.comment.debug.file=Saves an internally generated file for debugging purposes. This feature is not intended for regular users.
 ui.settings.label.tornado=TornadoVM root:
 ui.settings.label.java=Path to Java 21:

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -32,10 +32,11 @@ inspection.traps.throws=TornadoVM: Incompatible thrown types Exception in functi
 # ui
 ui.settings.comment.env=The environment variable file for TornadoVM is usually \"TornadoVM/setvars.sh\". \
   This file allows the plugin to call your host's TornadoVM for further analysis of Tornado methods.
-ui.settings.comment.size=Max array size specifies the length of Java variables when automatically initialized \
+ui.settings.max.array.size=Max array size specifies the length of Java variables when automatically initialized \
   by TornadoInsight. For example, when the parameter size is set to 32, and the type of a \
   parameter in a TornadoVM task is IntArray, it will It initialises an IntArray of length 32 \
   and fills it with random values.
+ui.settings.tensor.shape.dimensions.size=Tensor shape dimensions define the rank of a TornadoVM tensor type (i.e, the number of the dimensions of the shape). Once you have defined the number of dimensions click the <Set shape> button to configure the size of each dimension.
 ui.settings.comment.debug.file=Saves an internally generated file for debugging purposes. This feature is not intended for regular users.
 ui.settings.label.tornado=TornadoVM root:
 ui.settings.label.java=Path to Java 21:
@@ -45,6 +46,7 @@ ui.settings.group.debugging=Debug options
 ui.settings.group.dynamic=Dynamic Inspection
 ui.settings.validation.emptySize=Empty Parameter size
 ui.settings.validation.invalidSize=Parameter scale needs to be greater than 0 and less than 65534
+ui.settings.validation.shapeSize=Invalid shape size for a tensor. You defined at least one dimension as negative or zero.
 ui.settings.validation.emptyTornadovm=Empty TornadoVM path
 ui.settings.validation.emptyJava=Empty Java path
 ui.settings.validation.emptySave=Empty save location

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -31,12 +31,12 @@ inspection.traps.throws=TornadoVM: Incompatible thrown types Exception in functi
 
 # ui
 ui.settings.comment.env=The environment variable file for TornadoVM is usually \"TornadoVM/setvars.sh\". \
-  This file allows the plugin to call your host's TornadoVM for further analysis of Tornado methods.
+  This file allows the plugin to call your host's TornadoVM for further analysis of TornadoVM methods.
 ui.settings.max.array.size=Max array size specifies the length of Java variables when automatically initialized \
   by TornadoInsight. For example, when the parameter size is set to 32, and the type of a \
-  parameter in a TornadoVM task is IntArray, it will It initialises an IntArray of length 32 \
+  parameter in a TornadoVM task is IntArray, TornadoInsight creates an IntArray of length 32 \
   and fills it with random values.
-ui.settings.tensor.shape.dimensions.size=Tensor shape dimensions define the rank of a TornadoVM tensor type (i.e, the number of the dimensions of the shape). Once you have defined the number of dimensions click the <Set shape> button to configure the size of each dimension.
+ui.settings.tensor.shape.dimensions.size=Tensor shape dimensions define the rank of a TornadoVM tensor type (i.e, the number of the dimensions of the shape). Once you have defined the number of dimensions click the <b>Set shape</b> button to configure the size of each dimension.
 ui.settings.comment.debug.file=Saves an internally generated file for debugging purposes. This feature is not intended for regular users.
 ui.settings.label.tornado=TornadoVM root:
 ui.settings.label.java=Path to Java 21:


### PR DESCRIPTION
This PR added support for the [TornadoVM Tensor types](https://github.com/beehive-lab/TornadoVM/tree/master/tornado-api/src/main/java/uk/ac/manchester/tornado/api/types/tensors) (Issue #25).

Now, plugin users can define the shape for the tensor types from the plugin configuration panel, similar to the max array size. This configuration is dynamic, and users can update to run next configurations. Then the generated kernels from TornadoVM are generating the acceleration artifacts based on the user-defined shapes.

Some screenshot about the new features:
<img width="1400" alt="TornadoInsight-configuration-panel" src="https://github.com/user-attachments/assets/581433b8-9d48-45cc-a71a-eff48a0673a7">

**Note:** If the users want to run Tensor unit-tests but they do not define any shape, the default shape set by the plugin is 0, which forwards the misconfiguration to TornadoVM. In this case, TornadoVM should throw an invalid Shape configuration exception.

To test, you can use the `runIDE` Gradle option and open the new IDE. Then set your TornadoVM directory and the plugin configurations, and try the [TestTensorTypes](https://github.com/beehive-lab/TornadoVM/blob/master/tornado-unittests/src/main/java/uk/ac/manchester/tornado/unittests/tensors/TestTensorTypes.java) tests.

