### PR TITLE
Refactoring of classes to migrate to newer interfaces

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/TornadoSideWindow.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/ui/toolwindow/TornadoSideWindow.java
@@ -120,7 +120,13 @@ public class TornadoSideWindow implements ToolWindowFactory, Disposable {
             project.getMessageBus().connect().subscribe(TornadoTaskRefreshListener.REFRESH_TOPIC, new TornadoTaskRefreshListener() {
                 @Override
                 public void refresh() {
-                    TornadoTWTask.refresh(project, Objects.requireNonNull(FileEditorManager.getInstance(project).getSelectedFiles()[0]), getModel());
+                    VirtualFile[] selectedFiles = FileEditorManager.getInstance(project).getSelectedFiles();
+                    if (selectedFiles.length > 0) {
+                        TornadoTWTask.refresh(project, selectedFiles[0], getModel());
+                    } else {
+                        // Optional: handle the case where no file is selected
+                        System.out.println("No file selected in editor for Tornado refresh.");
+                    }
                 }
 
                 @Override


### PR DESCRIPTION
This PR contains some refactoring of the classes:

- `TornadoSettingListener` is migrated to use the `ProjectActivity` instead of `StartupActivity`.
- `TornadoSideWindow` has been refactored to consider the case that the selected files are empty.
- `TornadoTWTask` has been refactored to move slow operations to a background thread.