### PR TITLE
[refactor] Removed deprecated warmup method

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -107,7 +107,7 @@ public class CodeGenerator {
                 ".transferToHost(DataTransferMode.EVERY_EXECUTION" + taskGraphParameters + ");\n" + //
                 "ImmutableTaskGraph immutableTaskGraph = taskGraph.snapshot();\n" + //
                 "try (TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(immutableTaskGraph)) {\n" + //
-                "executionPlan.withWarmUp().execute();\n" + //
+                "executionPlan.execute();\n" + //
                 "        }\n" + //
                 "    }"; //
         MessageUtils.getInstance(project).showInfoMsg("Info", variableInit);


### PR DESCRIPTION
Following the changes merged in TornadoVM in this [PR](https://github.com/beehive-lab/TornadoVM/pull/686), we need a new update in order to make the plugin compatible with the latest `master` branch (after commit [da80056](https://github.com/beehive-lab/TornadoVM/commit/da80056791474135a310a2faac718fa6361ab754)).