### PR TITLE
[feat] Add Non-Void Return Type Inspection for TornadoVM Kernels Feat/non void return inspector

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/NonVoidReturnInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/NonVoidReturnInspection.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026, APT Group, Department of Computer Science,
+ *  The University of Manchester.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package uk.ac.manchester.beehive.tornado.plugins.inspector;
+
+import com.intellij.codeInspection.AbstractBaseJavaLocalInspectionTool;
+import com.intellij.codeInspection.ProblemHighlightType;
+import com.intellij.codeInspection.ProblemsHolder;
+import com.intellij.psi.*;
+import com.intellij.psi.util.PsiTreeUtil;
+import uk.ac.manchester.beehive.tornado.plugins.util.MessageBundle;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashSet;
+import java.util.Objects;
+
+/**
+ * A custom inspection tool to check for non-void return types in methods that are
+ * annotated with "Parallel" or "Reduce", or that have a KernelContext parameter.
+ * <p>
+ * Methods registered as kernel entry points via .task() must return void. However,
+ * non-void return types are valid when the method is inlined as a helper, so this
+ * inspection registers a WARNING rather than an ERROR.
+ * </p>
+ */
+public class NonVoidReturnInspection extends AbstractBaseJavaLocalInspectionTool {
+
+    @Override
+    public @NotNull PsiElementVisitor buildVisitor(@NotNull final ProblemsHolder holder, boolean isOnTheFly) {
+        HashSet<PsiMethod> reportedMethods = new HashSet<>();
+        return new JavaElementVisitor() {
+            @Override
+            public void visitAnnotation(@NotNull PsiAnnotation annotation) {
+                super.visitAnnotation(annotation);
+                if (Objects.requireNonNull(annotation.getQualifiedName()).endsWith("Parallel") ||
+                        annotation.getQualifiedName().endsWith("Reduce")) {
+                    PsiMethod parent = PsiTreeUtil.getParentOfType(annotation, PsiMethod.class);
+                    if (parent == null) return;
+                    checkReturnType(parent);
+                }
+            }
+
+            @Override
+            public void visitMethod(@NotNull PsiMethod method) {
+                super.visitMethod(method);
+
+                for (PsiParameter parameter : method.getParameterList().getParameters()) {
+                    PsiType type = parameter.getType();
+                    if (type.getCanonicalText().endsWith("KernelContext")) {
+                        checkReturnType(method);
+                        break;
+                    }
+                }
+            }
+
+            private void checkReturnType(PsiMethod method) {
+                if (reportedMethods.contains(method)) return;
+                reportedMethods.add(method);
+
+                PsiType returnType = method.getReturnType();
+                if (returnType != null && !PsiTypes.voidType().equals(returnType)) {
+                    PsiTypeElement returnTypeElement = method.getReturnTypeElement();
+                    if (returnTypeElement != null) {
+                        holder.registerProblem(returnTypeElement,
+                                MessageBundle.message("inspection.nonVoidReturn"),
+                                ProblemHighlightType.GENERIC_ERROR_OR_WARNING);
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/RecursionInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/RecursionInspection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2023, 2026, APT Group, Department of Computer Science,
  *  The University of Manchester.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ public class RecursionInspection extends AbstractBaseJavaLocalInspectionTool {
 
                 for (PsiParameter parameter : method.getParameterList().getParameters()) {
                     PsiType type = parameter.getType();
-                    if (type.getCanonicalText().equals("KernelContext")) {
+                    if (type.getCanonicalText().endsWith("KernelContext")) {
                         checkRecursion(method);
                         break;
                     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ThrowInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ThrowInspection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2023, 2026, APT Group, Department of Computer Science,
  *  The University of Manchester.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,7 +69,7 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
 
                 for (PsiParameter parameter : method.getParameterList().getParameters()) {
                     PsiType type = parameter.getType();
-                    if (type.getCanonicalText().equals("KernelContext")) {
+                    if (type.getCanonicalText().endsWith("KernelContext")) {
                         checkThrow(method);
                         break;
                     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, APT Group, Department of Computer Science,
+ * Copyright (c) 2023, 2026, APT Group, Department of Computer Science,
  *  The University of Manchester.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
@@ -260,6 +260,9 @@ public class TornadoTWTask {
         PsiElement[] errorElements = PsiTreeUtil.collectElements(method,
                 element -> element instanceof PsiErrorElement);
         if (errorElements.length != 0) return false;
+        // Kernel entry points registered via .task() must return void
+        PsiType returnType = method.getReturnType();
+        if (returnType != null && !PsiTypes.voidType().equals(returnType)) return false;
         return !ProblemMethods.getInstance().getMethodSet().contains(method.getText());
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023, APT Group, Department of Computer Science,
+  ~ Copyright (c) 2023, 2026, APT Group, Department of Computer Science,
   ~  The University of Manchester.
   ~
   ~  Licensed under the Apache License, Version 2.0 (the "License");
@@ -192,6 +192,14 @@ Enjoy and share your feedback!
                          enabledByDefault="true">
 
         </localInspection>
+        <localInspection language="JAVA"
+                         displayName="Non-void return type check"
+                         groupPath="Java"
+                         groupName="Java issues"
+                         shortName="NonVoidReturnInspection"
+                         level="WARNING"
+                         enabledByDefault="true"
+                         implementationClass="uk.ac.manchester.beehive.tornado.plugins.inspector.NonVoidReturnInspection"/>
         <toolWindow factoryClass="uk.ac.manchester.beehive.tornado.plugins.ui.toolwindow.TornadoSideWindow" id="TornadoVM" anchor="right" icon="TornadoIcons.TornadoIcon" />
         <applicationConfigurable instance="uk.ac.manchester.beehive.tornado.plugins.ui.settings.TornadoSettingConfiguration"
                                  displayName="TornadoInsight"/>

--- a/src/main/resources/messages/plugin_en.properties
+++ b/src/main/resources/messages/plugin_en.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2025, APT Group, Department of Computer Science,
+# Copyright (c) 2023, 2025-2026, APT Group, Department of Computer Science,
 #  The University of Manchester.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,6 +28,7 @@ inspection.traps.throw=TornadoVM does not support for Traps/Exceptions
 inspection.traps.tryCatch=TornadoVM: TornadoVM does not support for Traps/Exceptions. \
   The code block in Catch will be ignored, and the exception that may be thrown in Try block will not be handled
 inspection.traps.throws=TornadoVM: Incompatible thrown types Exception in functional expression
+inspection.nonVoidReturn=TornadoVM: Method returns a non-void type. This is supported when inlined as a helper, but kernel entry points registered via .task() must return void.
 
 # ui
 ui.settings.comment.env=The environment variable file for TornadoVM is usually \"TornadoVM/setvars.sh\". \


### PR DESCRIPTION
### Problem

Methods with `KernelContext` parameter or `@Parallel`/`@Reduce` annotations that return non-void compile fine in Java but fail at TornadoVM runtime when registered as .task() entry points.
     
They work only when they are inlined as helpers. No existing inspection warns about this.  

### Description

This PR introduces a new static inspection class that identifies such cases and marks the return non-void type with orange and a descriptive message.

The inspection registers a `WARNING` (not `ERROR`) on the method's return type element because non-void returns are valid when the method is inlined as a helper. The warning message clarifies this distinction. Consequently, `TornadoTWTask.validateTask()` now rejects methods with non-void return types, preventing them from appearing as selectable tasks in the TornadoVM side panel.

More specifically, it introduces these changes.

- Add a new static inspection (`NonVoidReturnInspection`) that warns when a method with `@Parallel`/`@Reduce` annotations or a `KernelContext` parameter returns a non-void type. These methods compile in Java but fail at TornadoVM runtime when registered as `.task()` entry points.
- Filter non-void returning methods from the TornadoVM Tasks panel, since they cannot be valid kernel entry points.
- Fix a bug in `ThrowInspection` and `RecursionInspection` where `KernelContext` parameter detection failed because `getCanonicalText()` returns the fully qualified name (e.g., `uk.ac.manchester.tornado.api.KernelContext`), but the check used `.equals("KernelContext")` instead of `.endsWith("KernelContext")`.                                                                                                                                                                
-  All inspections that detect `KernelContext` parameters (`ThrowInspection`, `RecursionInspection`, and the new `NonVoidReturnInspection`) now use  `getCanonicalText().endsWith("KernelContext")` to correctly match the fully qualified type name.
                                                                                                                                                                                      
  ## Suggested Test plan                                                                                                                                                                        
                                                                                                                                                                                      
  - [x] Open a Java file with a `KernelContext` method returning a non-void type (e.g., `float`)                                                                                      
  - [x] Verify the return type keyword is underlined with a warning                                                                                                                   
  - [x] Verify the method does not appear in the TornadoVM Tasks panel                                                                                                                
  - [x] Open a Java file with a `void` `KernelContext` method and verify no warning is shown                                                                                          
  - [x] Verify `ThrowInspection` and `RecursionInspection` now fire for `KernelContext`-only methods (no `@Parallel`/`@Reduce`) 