### PR TITLE
Fix TornadoVM executable and JDK-version detection on GUI-launched IDEs

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
@@ -318,6 +318,7 @@ public class ExecutionEngine {
         GeneralCommandLine commandLine = new GeneralCommandLine();
         commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
         commandLine.setExePath(resolveTornadoExe());
+        configureEnvironmentVariables(commandLine);
         commandLine.addParameter("--version");
 
         ProcessOutput output;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
@@ -337,7 +337,10 @@ public class ExecutionEngine {
         Matcher matcher = TORNADO_JDK_PATTERN.matcher(combined);
         if (matcher.find()) {
             try {
-                return Integer.parseInt(matcher.group(1));
+                int jdk = Integer.parseInt(matcher.group(1));
+                MessageUtils.getInstance(project).showInfoMsg("Info",
+                        "TornadoVM JDK version detected: " + jdk);
+                return jdk;
             } catch (NumberFormatException ignore) {
                 // Fall through to the structured-failure handling below.
             }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
@@ -85,6 +85,26 @@ public class ExecutionEngine {
         return System.getProperty("os.name").toLowerCase().contains("win");
     }
 
+    /**
+     * Resolves the {@code tornado} executable. Prefers an absolute path under
+     * {@code TORNADOVM_HOME/bin} (so the plugin works regardless of how the IDE
+     * was launched, since the JVM resolves a bare command name against the
+     * launching process's PATH rather than any PATH we set on the command line),
+     * and falls back to the bare executable name for a PATH lookup when the home
+     * is unknown or the binary is missing.
+     */
+    private static String resolveTornadoExe() {
+        String exe = isWindows() ? "tornado.exe" : "tornado";
+        String home = EnvironmentVariable.getTornadoSdk();
+        if (home != null && !home.isEmpty()) {
+            File candidate = new File(home, "bin" + File.separator + exe);
+            if (candidate.isFile()) {
+                return candidate.getAbsolutePath();
+            }
+        }
+        return exe;
+    }
+
     public void run(){
         // Performing UI related operations on a non-EDT is not allowed.
         MessageUtils.getInstance(project).showInfoMsg(MessageBundle.message("dynamic.info.title"),
@@ -297,7 +317,7 @@ public class ExecutionEngine {
     private Integer detectTornadoVmJdkVersion() {
         GeneralCommandLine commandLine = new GeneralCommandLine();
         commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
-        commandLine.setExePath(isWindows() ? "tornado.exe" : "tornado");
+        commandLine.setExePath(resolveTornadoExe());
         commandLine.addParameter("--version");
 
         ProcessOutput output;
@@ -468,8 +488,7 @@ public class ExecutionEngine {
         //Detecting if the user has correctly installed TornadoVM
         commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
         // On Windows, explicitly use tornado.exe to avoid trying to execute the Unix shell script
-        String tornadoExe = isWindows() ? "tornado.exe" : "tornado";
-        commandLine.setExePath(tornadoExe);
+        commandLine.setExePath(resolveTornadoExe());
         configureEnvironmentVariables(commandLine);
         commandLine.addParameter("--device");
 
@@ -571,8 +590,7 @@ public class ExecutionEngine {
         GeneralCommandLine commandLine = new GeneralCommandLine();
         commandLine.withParentEnvironmentType(GeneralCommandLine.ParentEnvironmentType.CONSOLE);
         // On Windows, explicitly use tornado.exe to avoid trying to execute the Unix shell script
-        String tornadoExe = isWindows() ? "tornado.exe" : "tornado";
-        commandLine.setExePath(tornadoExe);
+        commandLine.setExePath(resolveTornadoExe());
         configureEnvironmentVariables(commandLine);
         commandLine.addParameter("--printKernel");
 


### PR DESCRIPTION
**Problem**

  When the IDE is launched from a desktop launcher (JetBrains Toolbox, app icon) rather than a terminal, the `dynamic-inspection` run failed at the installation check with errors like:

```bash
  Could not determine the JDK that TornadoVM was built against.
  Failed to launch 'tornado --version': Cannot run program "tornado":
  error=2, No such file or directory

  and, once the executable was found:

  'tornado --version' exited with code 1.
  [ERROR] JAVA_HOME environment variable is not set
```

  **Root cause**

  A GUI-launched IDE does not inherit the shell environment set up in `~/.bashrc/` `~/.zshrc` (e.g. PATH entries added by
  `sdkman`, `JAVA_HOME`, `TORNADOVM_HOME`). Two issues followed from that:

  1. `detectTornadoVmJdkVersion()` launched the bare command tornado, which the JVM resolves against the launching process's
  PATH — not any PATH we set on the command line — so it wasn't found.
  2. That same method never called `configureEnvironmentVariables()`, so even once tornado was located it ran without
  JAVA_HOME and the launcher aborted.

  This primarily affects Linux/macOS; on Windows these variables live in the registry and are inherited by GUI processes.

  **Changes**

  - Add `resolveTornadoExe()`, which prefers an absolute path under `TORNADOVM_HOME/bin` and falls back to a bare-name PATH
  lookup. Route the `--version`, `--device`, and `--printKernel` invocations through it.
  - Call `configureEnvironmentVariables()` in the tornado --version check so it gets JAVA_HOME (from the project SDK),
 ` TORNADOVM_HOME`, and `PATH`, consistent with the other tornado calls.
  - Log the detected JDK to the console (TornadoVM JDK version detected: <n>), mirroring the existing `TORNADOVM_HOME` detected message.

  **Notes**

  - `JAVA_HOME` is derived from the project SDK, so the project JDK should be set (JDK 21/25) for the check to pass.

  **Testing**

  - Launched the IDE from the desktop launcher (no shell env): the version check now locates tornado, runs successfully,
  and reports the detected JDK in the console.