### PR TITLE
Support TornadoVM atomics (AtomicInteger) in static inspections

### DIFF
--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/CodeGenerator.java
@@ -99,8 +99,12 @@ public class CodeGenerator {
 
         String methodWithClass = filename + "::" + method.getName();
 
-        Optional<String> maybeOriginalTaskGraph = TornadoTWTask.extractOriginalTaskGraphDeclaration(TornadoTWTask.getPsiFile(), method.getName(), methodWithClass);
-        Optional<List<TornadoTWTask.TaskParametersInfo>> taskParametersInfos = TornadoTWTask.extractTasksParameters(TornadoTWTask.getPsiFile(), method.getName());
+        // The class may declare several TaskGraphs that reference this kernel by
+        // name; prefer the one whose .task(...) argument count matches the
+        // kernel's parameter count so we don't pick a stale/unrelated TaskGraph.
+        int kernelParamCount = method.getParameterList().getParametersCount();
+        Optional<String> maybeOriginalTaskGraph = TornadoTWTask.extractOriginalTaskGraphDeclaration(TornadoTWTask.getPsiFile(), method.getName(), methodWithClass, kernelParamCount);
+        Optional<List<TornadoTWTask.TaskParametersInfo>> taskParametersInfos = TornadoTWTask.extractTasksParameters(TornadoTWTask.getPsiFile(), method.getName(), kernelParamCount);
         String taskParameters = getTaskParameters(method, taskParametersInfos, fields);
         String mainCode = getTaskGraphCode(method, maybeOriginalTaskGraph, taskParameters, methodWithClass);
 
@@ -144,11 +148,29 @@ public class CodeGenerator {
             return VariableInit.variableInitHelper(method, localMemoryParams, intOverrides);
         }
 
+        // The arguments passed to .task("t0", Class::kernel, arg0, arg1, ...)
+        // map positionally onto the kernel's parameters. TornadoVM requires the
+        // argument type to match the kernel parameter type exactly (these are
+        // concrete types with no subtyping), so when the counts line up we
+        // allocate each harness variable with the KERNEL parameter's type
+        // rather than the type resolved from the user's source variable. The
+        // latter can be a mismatch (e.g. an IntArray variable passed to a
+        // LongArray/DoubleArray kernel parameter), which would generate code
+        // that does not compile against the strongly-typed TaskGraph.task(...)
+        // overloads. We keep the user's argument NAMES so the reused TaskGraph
+        // (which references them) still resolves.
+        PsiParameter[] kernelParams = method.getParameterList().getParameters();
+        boolean alignWithKernel = params.size() == kernelParams.length;
+
         ArrayList<String> names = new ArrayList<>(params.size());
         ArrayList<String> types = new ArrayList<>(params.size());
-        for (TornadoTWTask.TaskParametersInfo v : params) {
+        for (int i = 0; i < params.size(); i++) {
+            TornadoTWTask.TaskParametersInfo v = params.get(i);
             names.add(v.getName());
-            types.add(v.getType());
+            String kernelType = alignWithKernel && kernelParams[i].getTypeElement() != null
+                    ? kernelParams[i].getTypeElement().getText()
+                    : null;
+            types.add(kernelType != null ? kernelType : v.getType());
         }
         Map<String, String> intOverrides = collectIntParamOverrides(intParamNames(names, types), fields);
         return VariableInit.variableInitHelper(names, types, localMemoryParams, intOverrides);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/ExecutionEngine.java
@@ -443,7 +443,15 @@ public class ExecutionEngine {
             int exitCode = output.getExitCode();
             String stderr = output.getStderr();
             if (exitCode != 0) {
-                MessageUtils.getInstance(project).showErrorMsg("Internal error when running generated code", "Exit code: " + exitCode + "\n" + stderr);
+                // Surface a concise, human-readable warning instead of dumping
+                // the raw javac output. A type mismatch in the generated harness
+                // (e.g. a kernel parameter whose type the device does not
+                // support, such as FP64/double on a GPU without double support)
+                // produces hundreds of lines of overload candidates and
+                // type-variable declarations that bury the actual cause.
+                LOG.warn("Generated code compilation failed (exit code " + exitCode + "):\n" + stderr);
+                MessageUtils.getInstance(project).showWarnMsg("Generated code did not compile",
+                        summarizeCompilerErrors(stderr));
                 throw new UnsupportedOperationException("Compilation failed with exit code " + exitCode);
             }
         } catch (ExecutionException e) {
@@ -451,6 +459,127 @@ public class ExecutionEngine {
                     MessageBundle.message("dynamic.error.compile"));
         }
     }
+
+    // javac diagnostic header, e.g. "atomic18YxscA.java:49: error: no suitable method ..."
+    private static final Pattern COMPILE_DIAGNOSTIC =
+            Pattern.compile("\\.java:\\d+:\\s*(error|warning):");
+
+    // Kernel method name from the offending ".task(\"t0\", Class::kernel, ...)" line.
+    private static final Pattern KERNEL_REF = Pattern.compile("::(\\w+)");
+
+    /**
+     * Condenses raw {@code javac} output into the few lines that actually
+     * explain the failure. The generated TornadoVM harness calls the strongly
+     * typed {@code TaskGraph.task(...)} overloads, so a single argument-type
+     * mismatch makes the compiler print every {@code Task1..Task15} candidate
+     * plus a page of {@code where T1#1 extends Object ...} type-variable
+     * declarations. We keep the diagnostic headers, the offending source line
+     * and caret, and the {@code upper/lower bounds} lines that pinpoint the
+     * conflicting types, dropping the candidate/type-variable noise. When the
+     * failure is a {@code task(...)} type mismatch we append an explicit
+     * explanation, since the usual cause is a kernel parameter whose type the
+     * target device does not support (for example FP64/double on a GPU without
+     * double support).
+     */
+    static String summarizeCompilerErrors(String stderr) {
+        if (stderr == null || stderr.isBlank()) {
+            return "Compilation of the generated TornadoVM test failed, but the Java compiler produced no output to explain why.";
+        }
+        StringBuilder summary = new StringBuilder();
+        boolean typeMismatch = false;
+        String kernelName = null;     // kernel whose .task(...) call failed
+        String expectedType = null;   // type the kernel parameter expects (javac "upper bounds")
+        String actualType = null;     // type the harness actually allocated (javac "lower bounds")
+        int keepContext = 0; // remaining lines to keep after a diagnostic header (source + caret)
+        for (String line : stderr.split("\n")) {
+            String trimmed = line.strip();
+            if (COMPILE_DIAGNOSTIC.matcher(line).find()) {
+                summary.append(trimmed).append("\n");
+                keepContext = 2;
+                if (trimmed.contains("for task(")) {
+                    typeMismatch = true;
+                }
+                continue;
+            }
+            // Bound lines pinpoint the conflicting types - always keep them.
+            if (trimmed.startsWith("upper bounds:") || trimmed.startsWith("lower bounds:")
+                    || trimmed.contains("has incompatible bounds")) {
+                summary.append("    ").append(trimmed).append("\n");
+                typeMismatch = true;
+                if (trimmed.startsWith("upper bounds:")) {
+                    expectedType = firstType(trimmed.substring("upper bounds:".length()));
+                } else if (trimmed.startsWith("lower bounds:")) {
+                    actualType = firstType(trimmed.substring("lower bounds:".length()));
+                }
+                continue;
+            }
+            if (keepContext > 0) {
+                // Stop as soon as the overload-candidate / type-variable noise starts.
+                if (trimmed.startsWith("method ") || trimmed.startsWith("(")
+                        || trimmed.startsWith("where ")
+                        || trimmed.contains("extends Object declared in method")) {
+                    keepContext = 0;
+                } else {
+                    summary.append("    ").append(trimmed).append("\n");
+                    keepContext--;
+                    if (kernelName == null && trimmed.contains(".task(")) {
+                        Matcher m = KERNEL_REF.matcher(trimmed);
+                        if (m.find()) {
+                            kernelName = m.group(1);
+                        }
+                    }
+                }
+            }
+        }
+
+        if (summary.length() == 0) {
+            // No recognisable diagnostic header - fall back to the raw output so
+            // we never swallow the failure entirely.
+            return stderr.strip();
+        }
+
+        if (typeMismatch) {
+            summary.append("\n--- What this means ---\n");
+            summary.append("TornadoInsight generated a test harness that allocated the wrong data type for one of ")
+                    .append(kernelName != null ? "kernel '" + kernelName + "'s parameters" : "this kernel's parameters")
+                    .append(", so the strongly-typed TaskGraph.task(...) call does not type-check.\n");
+            if (expectedType != null && actualType != null) {
+                summary.append("    - The kernel parameter expects: ").append(expectedType).append("\n");
+                summary.append("    - The generated harness supplied: ").append(actualType).append("\n");
+            }
+            summary.append("\nThis is a type-detection bug in TornadoInsight's harness generator, not a limitation of your device. ")
+                    .append("Because this is a compile-time error, it cannot be caused by the device lacking support for a type ")
+                    .append("(an unsupported type, such as FP64/double on a GPU without double-precision support, would fail at run time, not here).\n");
+            summary.append("\nWhat you can do:\n");
+            summary.append("    - This kernel cannot be dynamically inspected until the generator emits a matching type.\n");
+            summary.append("    - Please report it, including the kernel signature and the expected/supplied types shown above.");
+        }
+        return summary.toString().strip();
+    }
+
+    /**
+     * Picks the first concrete type from a javac bounds list such as
+     * "DoubleArray,Object" or " IntArray", ignoring the trailing {@code Object}
+     * upper bound that javac always adds. Returns {@code null} if nothing usable
+     * is found.
+     */
+    private static String firstType(String boundsList) {
+        for (String part : boundsList.split(",")) {
+            // Keep only the leading type token; javac wraps the lower bound in
+            // "(inference variable ... )", so a trailing ')' can bleed in.
+            Matcher m = TYPE_TOKEN.matcher(part.strip());
+            if (m.find()) {
+                String t = m.group(1);
+                if (!t.equals("Object")) {
+                    return t;
+                }
+            }
+        }
+        return null;
+    }
+
+    // Leading Java type token, e.g. "DoubleArray", "int[]", "Foo<Bar>".
+    private static final Pattern TYPE_TOKEN = Pattern.compile("^([\\w.$]+(?:\\[\\])*(?:<[^>]*>)?)");
 
     private void packFolder(String classFolderPath, String outputFolderPath) {
         MessageUtils.getInstance(project).showInfoMsg(MessageBundle.message("dynamic.info.title"),
@@ -589,6 +718,51 @@ public class ExecutionEngine {
             "TornadoMemoryException",
     };
 
+    /**
+     * Recognises runtime failures that are caused by the target device lacking
+     * a capability the kernel needs (rather than a bug in the kernel or the
+     * generated harness), and returns a plain-language explanation. The harness
+     * was generated correctly in these cases - the kernel simply cannot run on
+     * this device - so the caller reports it as a warning instead of an error.
+     *
+     * <p>Note: this deliberately matches only TornadoVM's explicit
+     * "unsupported feature/type" messages, not generic OpenCL compiler
+     * exceptions (e.g. a {@code clBuildProgram} failure). A genuine compiler
+     * exception still surfaces as an error.
+     *
+     * @return a user-facing explanation, or {@code null} if the failure is not
+     *         a recognised device-capability limitation.
+     */
+    private static String describeDeviceLimitation(String combined) {
+        String lower = combined.toLowerCase();
+
+        // 64-bit floating point (FP64 / double precision).
+        if (lower.contains("cl_khr_fp64") || lower.contains("fp64")
+                || lower.contains("double precision")
+                || lower.contains("64-bit floating point")) {
+            return "this device does not support 64-bit floating point (FP64 / double precision). "
+                    + "Your kernel is valid, but TornadoVM cannot compile it for this device. "
+                    + "This is a device limitation, not an error in your kernel.";
+        }
+
+        // Floating-point atomic operations (e.g. atomicAdd on a float/double).
+        if (combined.contains("does not support floating point operations")) {
+            return "this device does not support floating-point atomic operations "
+                    + "(for example atomicAdd on a float or double). "
+                    + "Your kernel is valid, but TornadoVM cannot compile it for this device. "
+                    + "This is a device limitation, not an error in your kernel.";
+        }
+
+        // 16-bit floating point (FP16 / half).
+        if (combined.contains("TornadoDeviceFP16NotSupported")) {
+            return "this device does not support 16-bit floating point (FP16 / half). "
+                    + "Your kernel is valid, but TornadoVM cannot compile it for this device. "
+                    + "This is a device limitation, not an error in your kernel.";
+        }
+
+        return null;
+    }
+
     @NotNull
     private GeneralCommandLine getGeneralCommandLine(String jarPath) {
         GeneralCommandLine commandLine = new GeneralCommandLine();
@@ -665,12 +839,24 @@ public class ExecutionEngine {
                 hasRuntimeErrors = true;
                 MessageUtils consoleInstance = MessageUtils.getInstance(project);
 
-                // Collect all error lines from both stdout and stderr
-                String errorSummary = extractErrorLines(output);
-                String stderr = output.getStderr();
-                String errorDetail = errorSummary.isEmpty() ? stderr : errorSummary;
-                consoleInstance.showErrorMsg(MessageBundle.message("dynamic.info.title"),
-                        methodName + ": " + errorDetail);
+                String combined = output.getStdout() + "\n" + output.getStderr();
+                String deviceLimitation = describeDeviceLimitation(combined);
+
+                if (deviceLimitation != null) {
+                    // The kernel was generated correctly; it simply uses a
+                    // capability this device lacks (e.g. FP64). Report it as a
+                    // warning rather than a scary exception/stack trace.
+                    consoleInstance.showWarnMsg("Kernel not supported on this device",
+                            methodName + ": " + deviceLimitation);
+                } else {
+                    // Genuine error (including OpenCL compiler exceptions): keep
+                    // the raw diagnostic so it is not mistaken for a clean run.
+                    String errorSummary = extractErrorLines(output);
+                    String stderr = output.getStderr();
+                    String errorDetail = errorSummary.isEmpty() ? stderr : errorSummary;
+                    consoleInstance.showErrorMsg(MessageBundle.message("dynamic.info.title"),
+                            methodName + ": " + errorDetail);
+                }
 
                 // Show the generated kernel with error lines stripped out (for debugging)
                 String cleanKernel = stripErrorLines(output.getStdout());
@@ -680,8 +866,11 @@ public class ExecutionEngine {
 
                 consoleInstance.showInfoMsg(MessageBundle.message("dynamic.info.title"),
                         MessageBundle.message("dynamic.info.documentation"));
-                consoleInstance.showInfoMsg(MessageBundle.message("dynamic.info.title"),
-                        MessageBundle.message("dynamic.info.bug"));
+                // A device-capability limitation is not a bug, so don't prompt to report one.
+                if (deviceLimitation == null) {
+                    consoleInstance.showInfoMsg(MessageBundle.message("dynamic.info.title"),
+                            MessageBundle.message("dynamic.info.bug"));
+                }
             } else {
                 MessageUtils.getInstance(project).showInfoMsg(MessageBundle.message("dynamic.info.title"),
                         methodName + ": " + MessageBundle.message("dynamic.info.noException") );

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/dynamicInspection/VariableInit.java
@@ -144,6 +144,7 @@ public class VariableInit {
             case "VectorDouble", "VectorDouble2", "VectorDouble3", "VectorDouble4", "VectorDouble8", "VectorDouble16" -> vectorInit(name, type, "Double");
             case "VectorHalf", "VectorHalf2", "VectorHalf3", "VectorHalf4", "VectorHalf8", "VectorHalf16" -> vectorHalfInit(name, type);
             case "KernelContext" -> " = new KernelContext();";
+            case "AtomicInteger" -> "= new AtomicInteger(" + generateValueByType("Int") + ");";
             default -> "";
         };
     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/entity/RestrictedClasses.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/entity/RestrictedClasses.java
@@ -41,7 +41,17 @@ public enum RestrictedClasses {
         return className;
     }
 
+    // Classes that TornadoVM supports inside kernels despite living in a restricted package.
+    private static final String[] ALLOWED_EXCEPTIONS = {
+            "java.util.concurrent.atomic.AtomicInteger"
+    };
+
     public static boolean isRestrictedClass(String className) {
+        for (String allowed : ALLOWED_EXCEPTIONS) {
+            if (className.equals(allowed)) {
+                return false;
+            }
+        }
         for (RestrictedClasses restrictedClass : values()) {
             if (className.startsWith(restrictedClass.getClassName())) {
                 return true;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/AssertInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/AssertInspection.java
@@ -66,8 +66,10 @@ public class AssertInspection extends AbstractBaseJavaLocalInspectionTool {
                         @Override
                         public void visitAssertStatement(PsiAssertStatement statement) {
                             super.visitAssertStatement(statement);
+                            PsiElement anchor = scope.anchorFor(statement, method, holder.getFile());
+                            if (anchor == null) return;
                             ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                            holder.registerProblem(statement,
+                            holder.registerProblem(anchor,
                                     MessageBundle.message("inspection.assert") + context,
                                     ProblemHighlightType.ERROR);
                         }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/DataTypeInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/DataTypeInspection.java
@@ -106,7 +106,8 @@ public class DataTypeInspection extends AbstractBaseJavaLocalInspectionTool {
                         && !type.getCanonicalText().startsWith("double[]") && !type.getCanonicalText().startsWith("long[]")
                         && !type.getCanonicalText().startsWith("char[]") && !type.getCanonicalText().startsWith("float[]")
                         && !type.getCanonicalText().startsWith("byte[]") && !type.getCanonicalText().startsWith("short[]")
-                        && !type.equalsToText("Int3") && !type.getCanonicalText().startsWith("uk.ac.manchester.tornado.api.")) {
+                        && !type.equalsToText("Int3") && !type.getCanonicalText().startsWith("uk.ac.manchester.tornado.api.")
+                        && !type.getCanonicalText().startsWith("java.util.concurrent.atomic.AtomicInteger")) {
                     PsiMethod parentMethod = PsiTreeUtil.getParentOfType(variable, PsiMethod.class);
                     if (parentMethod != null) {
                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), parentMethod);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/DataTypeInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/DataTypeInspection.java
@@ -67,17 +67,20 @@ public class DataTypeInspection extends AbstractBaseJavaLocalInspectionTool {
                     method.accept(new JavaRecursiveElementVisitor() {
                         @Override
                         public void visitLocalVariable(PsiLocalVariable variable) {
-                            checkVariable(variable.getType(), variable, context);
+                            checkVariable(variable.getType(), variable, context,
+                                    scope.anchorFor(variable, method, holder.getFile()));
                         }
 
                         @Override
                         public void visitField(PsiField field) {
-                            checkVariable(field.getType(), field, context);
+                            checkVariable(field.getType(), field, context,
+                                    scope.anchorFor(field, method, holder.getFile()));
                         }
 
                         @Override
                         public void visitParameter(PsiParameter parameter) {
-                            checkVariable(parameter.getType(), parameter, context);
+                            checkVariable(parameter.getType(), parameter, context,
+                                    scope.anchorFor(parameter, method, holder.getFile()));
                         }
                     });
                 }
@@ -97,8 +100,11 @@ public class DataTypeInspection extends AbstractBaseJavaLocalInspectionTool {
              * @param type     The type of the variable to be checked.
              * @param variable The variable itself.
              * @param context  Helper context string for diagnostics.
+             * @param anchor   In-file element to register the problem on; null when
+             *                 the finding cannot be anchored in the inspected file.
              */
-            private void checkVariable(PsiType type, PsiVariable variable, String context) {
+            private void checkVariable(PsiType type, PsiVariable variable, String context, PsiElement anchor) {
+                if (anchor == null) return;
                 if (!type.equalsToText("int") && !type.equalsToText("boolean") && !type.equalsToText("double")
                         && !type.equalsToText("long") && !type.equalsToText("char") && !type.equalsToText("float")
                         && !type.equalsToText("byte") && !type.equalsToText("short")
@@ -108,12 +114,12 @@ public class DataTypeInspection extends AbstractBaseJavaLocalInspectionTool {
                         && !type.getCanonicalText().startsWith("byte[]") && !type.getCanonicalText().startsWith("short[]")
                         && !type.equalsToText("Int3") && !type.getCanonicalText().startsWith("uk.ac.manchester.tornado.api.")
                         && !type.getCanonicalText().startsWith("java.util.concurrent.atomic.AtomicInteger")) {
-                    PsiMethod parentMethod = PsiTreeUtil.getParentOfType(variable, PsiMethod.class);
+                    PsiMethod parentMethod = PsiTreeUtil.getParentOfType(anchor, PsiMethod.class);
                     if (parentMethod != null) {
                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), parentMethod);
                     }
                     holder.registerProblem(
-                            variable,
+                            anchor,
                             MessageBundle.message("inspection.datatype") + context,
                             ProblemHighlightType.ERROR
                     );

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ExternalLibraryInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ExternalLibraryInspection.java
@@ -76,8 +76,10 @@ public class ExternalLibraryInspection extends AbstractBaseJavaLocalInspectionTo
                                     if (qualifiedName != null && !qualifiedName.startsWith("java.") &&
                                             !qualifiedName.startsWith("uk.ac.manchester.tornado") &&
                                             !qualifiedName.startsWith("_Dummy_")) {
+                                        PsiElement anchor = scope.anchorFor(expression, method, holder.getFile());
+                                        if (anchor == null) return;
                                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                                        holder.registerProblem(expression,
+                                        holder.registerProblem(anchor,
                                                 MessageBundle.message("inspection.externalLibrary") + context,
                                                 ProblemHighlightType.WARNING);
                                     }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/KernelCallGraphAnalyzer.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/KernelCallGraphAnalyzer.java
@@ -55,11 +55,14 @@ public final class KernelCallGraphAnalyzer {
     public static final class AnalysisScope {
         private final List<PsiMethod> analyzableMethods;
         private final Map<PsiMethodCallExpression, String> nonAnalyzableCallSites;
+        private final Map<PsiMethod, PsiMethodCallExpression> rootCallSites;
 
         AnalysisScope(List<PsiMethod> analyzableMethods,
-                      Map<PsiMethodCallExpression, String> nonAnalyzableCallSites) {
+                      Map<PsiMethodCallExpression, String> nonAnalyzableCallSites,
+                      Map<PsiMethod, PsiMethodCallExpression> rootCallSites) {
             this.analyzableMethods = Collections.unmodifiableList(analyzableMethods);
             this.nonAnalyzableCallSites = Collections.unmodifiableMap(nonAnalyzableCallSites);
+            this.rootCallSites = Collections.unmodifiableMap(rootCallSites);
         }
 
         /**
@@ -75,6 +78,25 @@ public final class KernelCallGraphAnalyzer {
          */
         public Map<PsiMethodCallExpression, String> getNonAnalyzableCallSites() {
             return nonAnalyzableCallSites;
+        }
+
+        /**
+         * Returns an element inside {@code inspectedFile} on which a problem found
+         * on {@code element} may be registered. ProblemsHolder rejects elements from
+         * other files, so findings inside a helper that lives in another file are
+         * anchored to the call expression (in the inspected file) that leads to that
+         * helper. Returns the element itself when it already belongs to the inspected
+         * file, or {@code null} when no in-file anchor exists.
+         *
+         * @param element          the element the problem was found on
+         * @param containingMethod the analyzable method whose body contains the element
+         * @param inspectedFile    the file the ProblemsHolder belongs to
+         */
+        public PsiElement anchorFor(PsiElement element, PsiMethod containingMethod, PsiFile inspectedFile) {
+            if (element != null && element.getContainingFile() == inspectedFile) {
+                return element;
+            }
+            return rootCallSites.get(containingMethod);
         }
     }
 
@@ -101,20 +123,25 @@ public final class KernelCallGraphAnalyzer {
     private static AnalysisScope doResolve(PsiMethod kernelMethod) {
         List<PsiMethod> analyzable = new ArrayList<>();
         Map<PsiMethodCallExpression, String> nonAnalyzable = new LinkedHashMap<>();
+        Map<PsiMethod, PsiMethodCallExpression> rootCallSites = new HashMap<>();
         Set<PsiMethod> visited = new HashSet<>();
 
         analyzable.add(kernelMethod);
         visited.add(kernelMethod);
-        collectTransitiveCallees(kernelMethod, visited, analyzable, nonAnalyzable, 0);
+        collectTransitiveCallees(kernelMethod, kernelMethod.getContainingFile(), null,
+                visited, analyzable, nonAnalyzable, rootCallSites, 0);
 
-        return new AnalysisScope(analyzable, nonAnalyzable);
+        return new AnalysisScope(analyzable, nonAnalyzable, rootCallSites);
     }
 
     private static void collectTransitiveCallees(
             PsiMethod method,
+            PsiFile kernelFile,
+            PsiMethodCallExpression rootSite,
             Set<PsiMethod> visited,
             List<PsiMethod> analyzable,
             Map<PsiMethodCallExpression, String> nonAnalyzable,
+            Map<PsiMethod, PsiMethodCallExpression> rootCallSites,
             int depth) {
 
         if (depth >= MAX_INLINE_DEPTH) return;
@@ -126,11 +153,19 @@ public final class KernelCallGraphAnalyzer {
                 PsiTreeUtil.findChildrenOfType(body, PsiMethodCallExpression.class);
 
         for (PsiMethodCallExpression callExpr : calls) {
+            // Diagnostics must be registered on elements of the kernel's file;
+            // for calls inside an out-of-file helper, fall back to the kernel-file
+            // call expression that leads into that helper.
+            PsiMethodCallExpression site =
+                    callExpr.getContainingFile() == kernelFile ? callExpr : rootSite;
+
             PsiMethod resolved = callExpr.resolveMethod();
             if (resolved == null) {
-                nonAnalyzable.put(callExpr,
-                        "could not resolve call '" + callExpr.getText()
-                                + "' to a method declaration");
+                if (site != null) {
+                    nonAnalyzable.putIfAbsent(site,
+                            "could not resolve call '" + callExpr.getText()
+                                    + "' to a method declaration");
+                }
                 continue;
             }
 
@@ -138,15 +173,17 @@ public final class KernelCallGraphAnalyzer {
 
             String ineligibilityReason = checkEligibility(resolved);
             if (ineligibilityReason != null) {
-                if (isUserProjectMethod(resolved)) {
-                    nonAnalyzable.put(callExpr, ineligibilityReason);
+                if (isUserProjectMethod(resolved) && site != null) {
+                    nonAnalyzable.putIfAbsent(site, ineligibilityReason);
                 }
                 continue;
             }
 
             visited.add(resolved);
             analyzable.add(resolved);
-            collectTransitiveCallees(resolved, visited, analyzable, nonAnalyzable, depth + 1);
+            rootCallSites.put(resolved, site);
+            collectTransitiveCallees(resolved, kernelFile, site,
+                    visited, analyzable, nonAnalyzable, rootCallSites, depth + 1);
         }
     }
 
@@ -168,19 +205,22 @@ public final class KernelCallGraphAnalyzer {
         if (containingClass != null) {
             String qName = containingClass.getQualifiedName();
             if (qName != null) {
-                // Restricted system classes — not an error, just not analyzed
+                // Restricted system classes — never inlined; SystemCallInspection
+                // reports the call site itself.
                 if (RestrictedClasses.isRestrictedClass(qName)) {
-                    return null;
+                    return "'" + qName + "' is a restricted system class";
                 }
-                // TornadoVM API intrinsics — handled by runtime
+                // TornadoVM API intrinsics — replaced by the runtime, so their
+                // Java bodies must not be analyzed as kernel code
                 if (qName.startsWith("uk.ac.manchester.tornado.api.")) {
-                    return null;
+                    return "'" + qName + "' is a TornadoVM API intrinsic";
                 }
             }
         }
 
+        // Library methods are not kernel code; only user sources are inlined
         if (!isUserProjectMethod(method)) {
-            return null;
+            return "'" + method.getName() + "' is a library method";
         }
 
         return null;

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/RecursionInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/RecursionInspection.java
@@ -65,7 +65,7 @@ public class RecursionInspection extends AbstractBaseJavaLocalInspectionTool {
                         KernelCallGraphAnalyzer.resolve(kernelMethod);
 
                 for (PsiMethod method : scope.getAnalyzableMethods()) {
-                    checkRecursion(method, kernelMethod);
+                    checkRecursion(method, kernelMethod, scope);
                 }
 
                 for (var entry : scope.getNonAnalyzableCallSites().entrySet()) {
@@ -87,7 +87,7 @@ public class RecursionInspection extends AbstractBaseJavaLocalInspectionTool {
                                 KernelCallGraphAnalyzer.resolve(method);
 
                         for (PsiMethod m : scope.getAnalyzableMethods()) {
-                            checkRecursion(m, method);
+                            checkRecursion(m, method, scope);
                         }
 
                         for (var entry : scope.getNonAnalyzableCallSites().entrySet()) {
@@ -101,7 +101,8 @@ public class RecursionInspection extends AbstractBaseJavaLocalInspectionTool {
                 }
             }
 
-            private void checkRecursion(PsiMethod method, PsiMethod kernelMethod) {
+            private void checkRecursion(PsiMethod method, PsiMethod kernelMethod,
+                                        KernelCallGraphAnalyzer.AnalysisScope scope) {
                 String context = KernelCallGraphAnalyzer.helperContext(method, kernelMethod);
                 method.accept(new JavaRecursiveElementVisitor() {
                     @Override
@@ -111,9 +112,16 @@ public class RecursionInspection extends AbstractBaseJavaLocalInspectionTool {
                         Set<PsiMethod> visited = new HashSet<>();
                         if (isRecursive(calledMethod, visited)) {
                             if (calledMethod == null) return;
+                            // Prefer highlighting the recursive method declaration;
+                            // fall back to the call site when it is in another file.
+                            PsiElement anchor = scope.anchorFor(calledMethod, method, holder.getFile());
+                            if (anchor == null) {
+                                anchor = scope.anchorFor(callExpression, method, holder.getFile());
+                            }
+                            if (anchor == null) return;
                             ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
                             holder.registerProblem(
-                                    calledMethod,
+                                    anchor,
                                     MessageBundle.message("inspection.recursion") + context,
                                     ProblemHighlightType.ERROR);
                         }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/SystemCallInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/SystemCallInspection.java
@@ -72,9 +72,11 @@ public class SystemCallInspection extends AbstractBaseJavaLocalInspectionTool {
                         public void visitMethodCallExpression(PsiMethodCallExpression expression) {
                             super.visitMethodCallExpression(expression);
                             PsiMethod calledMethod = expression.resolveMethod();
+                            PsiElement anchor = scope.anchorFor(expression, method, holder.getFile());
+                            if (anchor == null) return;
                             if (calledMethod != null && calledMethod.hasModifierProperty(PsiModifier.NATIVE)) {
                                 ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                                holder.registerProblem(expression,
+                                holder.registerProblem(anchor,
                                         MessageBundle.message("inspection.nativeCall") + context,
                                         ProblemHighlightType.ERROR);
                             }
@@ -84,7 +86,7 @@ public class SystemCallInspection extends AbstractBaseJavaLocalInspectionTool {
                             assert className != null;
                             if (RestrictedClasses.isRestrictedClass(className)) {
                                 ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                                holder.registerProblem(expression,
+                                holder.registerProblem(anchor,
                                         MessageBundle.message("inspection.external") + context,
                                         ProblemHighlightType.ERROR);
                             }

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ThrowInspection.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/inspector/ThrowInspection.java
@@ -67,7 +67,7 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
                         KernelCallGraphAnalyzer.resolve(kernelMethod);
 
                 for (PsiMethod method : scope.getAnalyzableMethods()) {
-                    checkThrow(method, kernelMethod);
+                    checkThrow(method, kernelMethod, scope);
                 }
 
                 for (var entry : scope.getNonAnalyzableCallSites().entrySet()) {
@@ -89,7 +89,7 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
                                 KernelCallGraphAnalyzer.resolve(method);
 
                         for (PsiMethod m : scope.getAnalyzableMethods()) {
-                            checkThrow(m, method);
+                            checkThrow(m, method, scope);
                         }
 
                         for (var entry : scope.getNonAnalyzableCallSites().entrySet()) {
@@ -103,15 +103,18 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
                 }
             }
 
-            private void checkThrow(PsiMethod method, PsiMethod kernelMethod) {
+            private void checkThrow(PsiMethod method, PsiMethod kernelMethod,
+                                    KernelCallGraphAnalyzer.AnalysisScope scope) {
                 String context = KernelCallGraphAnalyzer.helperContext(method, kernelMethod);
                 method.accept(new JavaRecursiveElementVisitor() {
                     @Override
                     public void visitThrowStatement(PsiThrowStatement statement) {
                         super.visitThrowStatement(statement);
                         if (!reportedStatement.contains(statement)) {
+                            PsiElement anchor = scope.anchorFor(statement, method, holder.getFile());
+                            if (anchor == null) return;
                             ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                            holder.registerProblem(statement,
+                            holder.registerProblem(anchor,
                                     MessageBundle.message("inspection.traps.throw") + context,
                                     ProblemHighlightType.ERROR);
                             reportedStatement.add(statement);
@@ -120,8 +123,10 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
                     @Override
                     public void visitTryStatement(PsiTryStatement statement) {
                         super.visitTryStatement(statement);
+                        PsiElement anchor = scope.anchorFor(statement, method, holder.getFile());
+                        if (anchor == null) return;
                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);
-                        holder.registerProblem(statement,
+                        holder.registerProblem(anchor,
                                 MessageBundle.message("inspection.traps.tryCatch") + context,
                                 ProblemHighlightType.ERROR);
                     }
@@ -130,7 +135,9 @@ public class ThrowInspection extends AbstractBaseJavaLocalInspectionTool {
                 // Checking the method signature for thrown exceptions
                 if (!reportedMethod.contains(method)) {
                     for (PsiClassType exception : method.getThrowsList().getReferencedTypes()) {
-                        holder.registerProblem(method.getThrowsList(),
+                        PsiElement anchor = scope.anchorFor(method.getThrowsList(), method, holder.getFile());
+                        if (anchor == null) continue;
+                        holder.registerProblem(anchor,
                                 MessageBundle.message("inspection.traps.throws") + "\n" + exception.getCanonicalText() + context,
                                 ProblemHighlightType.ERROR);
                         ProblemMethods.getInstance().addMethod(holder.getProject(), holder.getFile(), kernelMethod);

--- a/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
+++ b/src/main/java/uk/ac/manchester/beehive/tornado/plugins/util/TornadoTWTask.java
@@ -454,23 +454,49 @@ public class TornadoTWTask {
      * @return an {@code Optional<String>} containing the updated TaskGraph declaration if found; otherwise, {@code Optional.empty()}
      */
     public static Optional<String> extractOriginalTaskGraphDeclaration(PsiFile psiFile, String methodName, String methodWithClass) {
+        return extractOriginalTaskGraphDeclaration(psiFile, methodName, methodWithClass, -1);
+    }
+
+    /**
+     * As {@link #extractOriginalTaskGraphDeclaration(PsiFile, String, String)},
+     * but disambiguates between several {@link TaskGraph} declarations that
+     * reference the same kernel name: when {@code expectedArgCount >= 0} it
+     * prefers the declaration whose {@code .task(...)} passes that many
+     * arguments (matching the kernel's parameter count), so a stale or unrelated
+     * TaskGraph for the same method name is not picked over the matching one.
+     */
+    public static Optional<String> extractOriginalTaskGraphDeclaration(PsiFile psiFile, String methodName,
+                                                                       String methodWithClass, int expectedArgCount) {
         Collection<PsiDeclarationStatement> declarations = PsiTreeUtil.findChildrenOfType(psiFile, PsiDeclarationStatement.class);
+        PsiDeclarationStatement fallback = null;
         for (PsiDeclarationStatement declaration : declarations) {
             for (PsiElement element : declaration.getDeclaredElements()) {
-                if (element instanceof PsiLocalVariable variable) {
-                    PsiType type = variable.getType();
-                    if (type.getCanonicalText().contains("TaskGraph")) {
-                        String code = declaration.getText();
-                        if (code.contains(".task(") && code.contains(methodName)) {
+                if (!(element instanceof PsiLocalVariable variable)) continue;
+                PsiType type = variable.getType();
+                if (type == null || !type.getCanonicalText().contains("TaskGraph")) continue;
 
-                            String updatedCode = code.replaceAll("(\\.task\\s*\\(\\s*\"[^\"]+\"\\s*,\\s*)([\\w\\.]+::\\w+)","$1" + methodWithClass);
-                            return Optional.of(updatedCode);
-                        }
-                    }
+                // Match precisely on a .task(...) that references this method,
+                // rather than a loose substring search over the declaration text.
+                int argCount = taskArgCountForMethod(declaration, methodName);
+                if (argCount < 0) continue;
+
+                if (fallback == null) {
+                    fallback = declaration;
+                }
+                if (expectedArgCount < 0 || argCount == expectedArgCount) {
+                    return Optional.of(rewriteTaskMethodReference(declaration.getText(), methodWithClass));
                 }
             }
         }
-        return Optional.empty();
+        return fallback != null
+                ? Optional.of(rewriteTaskMethodReference(fallback.getText(), methodWithClass))
+                : Optional.empty();
+    }
+
+    // Rewrites the method reference inside .task("name", Class::kernel, ...) to
+    // point at the generated harness class.
+    private static String rewriteTaskMethodReference(String code, String methodWithClass) {
+        return code.replaceAll("(\\.task\\s*\\(\\s*\"[^\"]+\"\\s*,\\s*)([\\w\\.]+::\\w+)", "$1" + methodWithClass);
     }
 
     /**
@@ -491,9 +517,22 @@ public class TornadoTWTask {
     }
 
     public static Optional<List<TaskParametersInfo>> extractTasksParameters(PsiFile psiFile, String methodName) {
+        return extractTasksParameters(psiFile, methodName, -1);
+    }
+
+    /**
+     * Extracts the arguments passed to the {@code .task(...)} call that invokes
+     * {@code methodName}. A class may declare several {@link TaskGraph}s that
+     * reference the same kernel name, so when {@code expectedArgCount >= 0} we
+     * prefer the {@code .task(...)} whose argument count matches the kernel's
+     * parameter count, falling back to the first match only if none line up.
+     */
+    public static Optional<List<TaskParametersInfo>> extractTasksParameters(PsiFile psiFile, String methodName,
+                                                                            int expectedArgCount) {
         Collection<PsiDeclarationStatement> declarations =
                 PsiTreeUtil.findChildrenOfType(psiFile, PsiDeclarationStatement.class);
 
+        List<TaskParametersInfo> fallback = null;
         for (PsiDeclarationStatement declaration : declarations) {
             for (PsiElement element : declaration.getDeclaredElements()) {
                 if (!(element instanceof PsiLocalVariable variable)) continue;
@@ -513,15 +552,7 @@ public class TornadoTWTask {
                     if (args.length < 2) continue; // need at least task name + method ref
 
                     // 2nd arg must be a method reference to methodName
-                    PsiExpression second = args[1];
-                    boolean matches;
-                    if (second instanceof PsiMethodReferenceExpression mref) {
-                        matches = methodName.equals(mref.getReferenceName());
-                    } else {
-                        String txt = second.getText();
-                        matches = txt != null && txt.contains("::" + methodName);
-                    }
-                    if (!matches) continue;
+                    if (!taskRefMatches(args[1], methodName)) continue;
 
                     List<TaskParametersInfo> vars = new ArrayList<>();
                     for (int i = 2; i < args.length; i++) {
@@ -532,11 +563,53 @@ public class TornadoTWTask {
                         if (typeText == null || typeText.isEmpty()) typeText = "<unknown>";
                         vars.add(new TaskParametersInfo(name, typeText));
                     }
-                    return Optional.of(vars);
+                    // Prefer the .task(...) whose argument count matches the
+                    // kernel signature; remember the first match as a fallback.
+                    if (expectedArgCount < 0 || vars.size() == expectedArgCount) {
+                        return Optional.of(vars);
+                    }
+                    if (fallback == null) {
+                        fallback = vars;
+                    }
                 }
             }
         }
-        return Optional.empty();
+        return Optional.ofNullable(fallback);
+    }
+
+    /**
+     * Whether the second argument of a {@code .task("name", Class::kernel, ...)}
+     * call references {@code methodName}. Uses an exact reference-name match for
+     * a real method-reference expression, and an {@code endsWith("::name")} text
+     * match otherwise so that prefixes (e.g. {@code atomic18} vs
+     * {@code atomic180}) are not confused.
+     */
+    private static boolean taskRefMatches(PsiExpression second, String methodName) {
+        if (second instanceof PsiMethodReferenceExpression mref) {
+            return methodName.equals(mref.getReferenceName());
+        }
+        String txt = second.getText();
+        return txt != null && txt.endsWith("::" + methodName);
+    }
+
+    /**
+     * Returns the number of arguments the {@code .task(...)} call that invokes
+     * {@code methodName} passes to the kernel (i.e. excluding the task name and
+     * the method reference), or {@code -1} if {@code scope} contains no such
+     * call.
+     */
+    private static int taskArgCountForMethod(PsiElement scope, String methodName) {
+        Collection<PsiMethodCallExpression> calls =
+                PsiTreeUtil.findChildrenOfType(scope, PsiMethodCallExpression.class);
+        for (PsiMethodCallExpression call : calls) {
+            if (!"task".equals(call.getMethodExpression().getReferenceName())) continue;
+            PsiExpression[] args = call.getArgumentList().getExpressions();
+            if (args.length < 2) continue;
+            if (taskRefMatches(args[1], methodName)) {
+                return args.length - 2;
+            }
+        }
+        return -1;
     }
 
     public static class TaskParametersInfo {


### PR DESCRIPTION
**Summary**

  Kernels that use java.util.concurrent.atomic.AtomicInteger — which TornadoVM supports and exercises in its own TestAtomics unit tests — were rejected by TornadoInsight's static
  inspections. For example:

```java
  public static void atomic04(IntArray input) {
      AtomicInteger tai = new AtomicInteger(200);
      for (@Parallel int i = 0; i < input.getSize(); i++) {
          input.set(i, tai.incrementAndGet());
      }
  }
```

This was flagged twice: DataTypeInspection marked the AtomicInteger variable as an unsupported kernel type, and SystemCallInspection marked tai.incrementAndGet() as a forbidden JDK call because the entire java.util.concurrent package is blacklisted in RestrictedClasses.

While testing atomics, kernels calling KernelContext.atomicAdd also surfaced a PluginException: inspections inlined the TornadoVM API method body and registered problems on PSI elements of KernelContext.java, while the ProblemsHolder belongs to the user's file — which the platform rejects.

  **Changes**

  Support `AtomicInteger` in kernel code:
  - `DataTypeInspection`: whitelist java.util.concurrent.atomic.AtomicInteger (covers AtomicInteger[] as well).
  - `RestrictedClasses`: add an ALLOWED_EXCEPTIONS list, checked before the package-prefix match, containing exactly java.util.concurrent.atomic.AtomicInteger — the rest of java.util.concurrent (executors, locks, etc.) remains blocked.

  Fix invalid `ProblemDescriptor` for cross-file helpers
  - `KernelCallGraphAnalyzer.checkEligibility`: TornadoVM API intrinsics (e.g. KernelContext.atomicAdd), restricted system classes, and any method outside the project's source roots are no longer inlined for analysis — they are runtime-handled library code, not kernel code. (Previously these branches fell through and returned "eligible".)
  - `KernelCallGraphAnalyzer` now records, for every inlined helper, the call expression in the kernel's file that leads to it, exposed via AnalysisScope.anchorFor(...). Non-analyzable call-site diagnostics are anchored the same way.
  - All call-graph-based inspections (DataTypeInspection, SystemCallInspection, ExternalLibraryInspection, AssertInspection, ThrowInspection, RecursionInspection) now register findings from helpers in other files on that kernel-file call site instead of the foreign element, with the existing "in helper '…' inlined into kernel" context suffix preserved.

  **Testing**

  - Verified in the sandbox IDE with TornadoVM's `TestAtomics: atomic04` (local AtomicInteger + incrementAndGet()) shows no false errors, and kernels using `KernelContext.atomicAdd` no longer trigger the PluginException.
  - Other `java.util.concurrent` usages are still reported as restricted calls.